### PR TITLE
Refactoring PlainTextPassword to a more meaningful name

### DIFF
--- a/core/impl/src/main/java/org/picketlink/credential/internal/DefaultLoginCredentials.java
+++ b/core/impl/src/main/java/org/picketlink/credential/internal/DefaultLoginCredentials.java
@@ -7,7 +7,7 @@ import javax.inject.Named;
 import org.picketlink.authentication.event.LoginFailedEvent;
 import org.picketlink.authentication.event.PostAuthenticateEvent;
 import org.picketlink.idm.credential.Credentials;
-import org.picketlink.idm.credential.PlainTextPassword;
+import org.picketlink.idm.credential.EncodedPassword;
 import org.picketlink.idm.model.Agent;
 
 /**
@@ -46,8 +46,8 @@ public class DefaultLoginCredentials implements Credentials
     
     public String getPassword()
     {  
-        if(credential != null && credential instanceof PlainTextPassword){
-            PlainTextPassword ptp = (PlainTextPassword) credential;
+        if(credential != null && credential instanceof EncodedPassword){
+            EncodedPassword ptp = (EncodedPassword) credential;
             return new String(ptp.getValue());
         }
         return null;
@@ -58,7 +58,7 @@ public class DefaultLoginCredentials implements Credentials
      */
     public void setPassword(final String password)
     {
-        this.credential = new PlainTextPassword(password.toCharArray());
+        this.credential = new EncodedPassword(password.toCharArray());
     }
 
     public void invalidate()

--- a/idm/api/src/main/java/org/picketlink/idm/credential/EncodedPassword.java
+++ b/idm/api/src/main/java/org/picketlink/idm/credential/EncodedPassword.java
@@ -5,14 +5,14 @@ package org.picketlink.idm.credential;
  * 
  * @author Shane Bryzak
  */
-public class PlainTextPassword {
+public class EncodedPassword {
 
     private char[] value;
 
-    public PlainTextPassword(char[] value) {
+    public EncodedPassword(char[] value) {
         this.value = value;
     }
-    public PlainTextPassword(String str) {
+    public EncodedPassword(String str) {
         this.value = str.toCharArray();
     }
 

--- a/idm/api/src/main/java/org/picketlink/idm/credential/OTPCredential.java
+++ b/idm/api/src/main/java/org/picketlink/idm/credential/OTPCredential.java
@@ -26,7 +26,7 @@ package org.picketlink.idm.credential;
  * @author anil saldhana
  * @since Dec 31, 2012
  */
-public class OTPCredential extends PlainTextPassword {
+public class OTPCredential extends EncodedPassword {
     public OTPCredential(char[] value) {
         super(value);
     }

--- a/idm/api/src/main/java/org/picketlink/idm/credential/UsernamePasswordCredentials.java
+++ b/idm/api/src/main/java/org/picketlink/idm/credential/UsernamePasswordCredentials.java
@@ -10,13 +10,13 @@ public class UsernamePasswordCredentials extends AbstractBaseCredentials {
 
     private String username;
 
-    private PlainTextPassword password;
+    private EncodedPassword password;
 
     public UsernamePasswordCredentials() {
         
     }
     
-    public UsernamePasswordCredentials(String userName, PlainTextPassword password) {
+    public UsernamePasswordCredentials(String userName, EncodedPassword password) {
         this.username = userName;
         this.password = password;
     }
@@ -30,11 +30,11 @@ public class UsernamePasswordCredentials extends AbstractBaseCredentials {
         return this;
     }
 
-    public PlainTextPassword getPassword() {
+    public EncodedPassword getPassword() {
         return password;
     }
 
-    public UsernamePasswordCredentials setPassword(PlainTextPassword password) {
+    public UsernamePasswordCredentials setPassword(EncodedPassword password) {
         this.password = password;
         return this;
     }

--- a/idm/impl/src/main/java/org/picketlink/idm/credential/internal/DigestCredentialHandler.java
+++ b/idm/impl/src/main/java/org/picketlink/idm/credential/internal/DigestCredentialHandler.java
@@ -8,11 +8,10 @@ import org.picketlink.idm.credential.Credentials.Status;
 import org.picketlink.idm.credential.Digest;
 import org.picketlink.idm.credential.DigestCredentials;
 import org.picketlink.idm.credential.DigestUtil;
-import org.picketlink.idm.credential.PlainTextPassword;
 import org.picketlink.idm.credential.spi.CredentialHandler;
 import org.picketlink.idm.credential.spi.annotations.SupportsCredentials;
 import org.picketlink.idm.model.Agent;
-import org.picketlink.idm.password.internal.PlainTextPasswordStorage;
+import org.picketlink.idm.password.internal.EncodedPasswordStorage;
 import org.picketlink.idm.spi.CredentialStore;
 import org.picketlink.idm.spi.IdentityStore;
 
@@ -21,8 +20,8 @@ import org.picketlink.idm.spi.IdentityStore;
  * This particular implementation supports the validation of {@link DigestCredentials}.
  * </p>
  * <p>
- * Digest validation requires that the password was previously stored as a {@link PlainTextPassword} without encoding using the
- * {@link PlainTextPasswordStorage}.
+ * Digest validation requires that the password was previously stored as a {@link org.picketlink.idm.credential.EncodedPassword} without encoding using the
+ * {@link org.picketlink.idm.password.internal.EncodedPasswordStorage}.
  * </p>
  * 
  * @author Shane Bryzak
@@ -43,7 +42,7 @@ public class DigestCredentialHandler implements CredentialHandler {
         
         CredentialStore credentialStore = (CredentialStore) identityStore;
         
-        PlainTextPasswordStorage storedPassword = credentialStore.retrieveCurrentCredential(agent, PlainTextPasswordStorage.class);
+        EncodedPasswordStorage storedPassword = credentialStore.retrieveCurrentCredential(agent, EncodedPasswordStorage.class);
 
         if (storedPassword != null) {
             if (DigestUtil.matchCredential(digestCredential.getDigest(), storedPassword.getPassword().toCharArray())) {

--- a/idm/impl/src/main/java/org/picketlink/idm/credential/internal/PasswordCredentialHandler.java
+++ b/idm/impl/src/main/java/org/picketlink/idm/credential/internal/PasswordCredentialHandler.java
@@ -8,7 +8,7 @@ import java.util.List;
 import org.picketlink.idm.IdentityManagementException;
 import org.picketlink.idm.credential.Credentials;
 import org.picketlink.idm.credential.Credentials.Status;
-import org.picketlink.idm.credential.PlainTextPassword;
+import org.picketlink.idm.credential.EncodedPassword;
 import org.picketlink.idm.credential.UsernamePasswordCredentials;
 import org.picketlink.idm.credential.spi.CredentialHandler;
 import org.picketlink.idm.credential.spi.CredentialStorage;
@@ -22,17 +22,17 @@ import org.picketlink.idm.spi.IdentityStore;
 /**
  * <p>
  * This particular implementation supports the validation of {@link UsernamePasswordCredentials}, and updating
- * {@link PlainTextPassword} credentials.
+ * {@link org.picketlink.idm.credential.EncodedPassword} credentials.
  * </p>
  * <p>
  * Passwords can be encoded or not. This behavior is configured by setting the <code>encodedPassword</code> property of the
- * {@link PlainTextPassword}.
+ * {@link org.picketlink.idm.credential.EncodedPassword}.
  * </p>
  * 
  * @author Shane Bryzak
  * @author <a href="mailto:psilva@redhat.com">Pedro Silva</a>
  */
-@SupportsCredentials({ UsernamePasswordCredentials.class, PlainTextPassword.class })
+@SupportsCredentials({ UsernamePasswordCredentials.class, EncodedPassword.class })
 public class PasswordCredentialHandler implements CredentialHandler {
 
     @Override
@@ -73,12 +73,12 @@ public class PasswordCredentialHandler implements CredentialHandler {
     public void update(Agent agent, Object credential, IdentityStore<?> identityStore, Date effectiveDate, Date expiryDate) {
         CredentialStore store = validateCredentialStore(identityStore);
 
-        if (!PlainTextPassword.class.isInstance(credential)) {
+        if (!EncodedPassword.class.isInstance(credential)) {
             throw new IllegalArgumentException("Credential class [" + credential.getClass().getName()
                     + "] not supported by this handler.");
         }
 
-        PlainTextPassword password = (PlainTextPassword) credential;
+        EncodedPassword password = (EncodedPassword) credential;
 
         SHASaltedPasswordEncoder encoder = new SHASaltedPasswordEncoder(512);
         SHASaltedPasswordHash hash = new SHASaltedPasswordHash();

--- a/idm/impl/src/main/java/org/picketlink/idm/ldap/internal/LDAPPlainTextPasswordCredentialHandler.java
+++ b/idm/impl/src/main/java/org/picketlink/idm/ldap/internal/LDAPPlainTextPasswordCredentialHandler.java
@@ -9,7 +9,7 @@ import javax.naming.directory.ModificationItem;
 
 import org.picketlink.idm.credential.Credentials;
 import org.picketlink.idm.credential.Credentials.Status;
-import org.picketlink.idm.credential.PlainTextPassword;
+import org.picketlink.idm.credential.EncodedPassword;
 import org.picketlink.idm.credential.UsernamePasswordCredentials;
 import org.picketlink.idm.credential.spi.CredentialHandler;
 import org.picketlink.idm.credential.spi.annotations.SupportsCredentials;
@@ -17,12 +17,12 @@ import org.picketlink.idm.model.Agent;
 import org.picketlink.idm.spi.IdentityStore;
 
 /**
- * This particular implementation supports the validation of UsernamePasswordCredentials, and updating PlainTextPassword credentials.
+ * This particular implementation supports the validation of UsernamePasswordCredentials, and updating EncodedPassword credentials.
  *
  * @author Shane Bryzak
  * @author <a href="mailto:psilva@redhat.com">Pedro Silva</a>
  */
-@SupportsCredentials({UsernamePasswordCredentials.class, PlainTextPassword.class})
+@SupportsCredentials({UsernamePasswordCredentials.class, EncodedPassword.class})
 public class LDAPPlainTextPasswordCredentialHandler implements CredentialHandler {
     
     private static final String USER_PASSWORD_ATTRIBUTE = "userpassword";
@@ -60,12 +60,12 @@ public class LDAPPlainTextPasswordCredentialHandler implements CredentialHandler
     public void update(Agent agent, Object credential, IdentityStore<?> identityStore, Date effectiveDate, Date expiryDate) {
         checkIdentityStoreInstance(identityStore);
         
-        if (!PlainTextPassword.class.isInstance(credential)) {
+        if (!EncodedPassword.class.isInstance(credential)) {
             throw new IllegalArgumentException("Credential class [" + credential.getClass().getName()
                     + "] not supported by this handler.");
         }
 
-        PlainTextPassword password = (PlainTextPassword) credential;
+        EncodedPassword password = (EncodedPassword) credential;
 
         LDAPIdentityStore ldapIdentityStore = (LDAPIdentityStore) identityStore;
         LDAPUser ldapuser = (LDAPUser) ldapIdentityStore.getUser(agent.getId());

--- a/idm/impl/src/main/java/org/picketlink/idm/password/internal/EncodedPasswordStorage.java
+++ b/idm/impl/src/main/java/org/picketlink/idm/password/internal/EncodedPasswordStorage.java
@@ -9,17 +9,17 @@ import org.picketlink.idm.credential.spi.annotations.Stored;
  * @author <a href="mailto:psilva@redhat.com">Pedro Silva</a>
  *
  */
-public class PlainTextPasswordStorage implements CredentialStorage {
+public class EncodedPasswordStorage implements CredentialStorage {
 
     private Date effectiveDate;
     private Date expiryDate;
     private String password;
 
-    public PlainTextPasswordStorage() {
+    public EncodedPasswordStorage() {
 
     }
 
-    public PlainTextPasswordStorage(String password) {
+    public EncodedPasswordStorage(String password) {
         setPassword(password);
     }
 

--- a/idm/impl/src/test/java/org/picketlink/test/idm/PasswordCredentialTestCase.java
+++ b/idm/impl/src/test/java/org/picketlink/test/idm/PasswordCredentialTestCase.java
@@ -29,7 +29,7 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.picketlink.idm.IdentityManager;
 import org.picketlink.idm.credential.Credentials.Status;
-import org.picketlink.idm.credential.PlainTextPassword;
+import org.picketlink.idm.credential.EncodedPassword;
 import org.picketlink.idm.credential.UsernamePasswordCredentials;
 import org.picketlink.idm.model.User;
 
@@ -54,14 +54,14 @@ public class PasswordCredentialTestCase extends AbstractIdentityManagerTestCase 
     public void testSuccessfulValidation() throws Exception {
         IdentityManager identityManager = getIdentityManager();
         User user = loadOrCreateUser("someUser", true);
-        PlainTextPassword plainTextPassword = new PlainTextPassword("updated_password".toCharArray());
+        EncodedPassword encodedPassword = new EncodedPassword("updated_password".toCharArray());
 
-        identityManager.updateCredential(user, plainTextPassword, new Date(), null);
+        identityManager.updateCredential(user, encodedPassword, new Date(), null);
 
         UsernamePasswordCredentials credential = new UsernamePasswordCredentials();
 
         credential.setUsername(user.getId());
-        credential.setPassword(plainTextPassword);
+        credential.setPassword(encodedPassword);
 
         identityManager.validateCredentials(credential);
 
@@ -79,13 +79,13 @@ public class PasswordCredentialTestCase extends AbstractIdentityManagerTestCase 
     public void testUnsuccessfulValidation() throws Exception {
         IdentityManager identityManager = getIdentityManager();
         User user = loadOrCreateUser("someUser", true);
-        PlainTextPassword plainTextPassword = new PlainTextPassword("updated_password".toCharArray());
+        EncodedPassword encodedPassword = new EncodedPassword("updated_password".toCharArray());
 
-        identityManager.updateCredential(user, plainTextPassword, new Date(), null);
+        identityManager.updateCredential(user, encodedPassword, new Date(), null);
         UsernamePasswordCredentials badUserName = new UsernamePasswordCredentials();
 
         badUserName.setUsername("Bad" + user.getId());
-        badUserName.setPassword(plainTextPassword);
+        badUserName.setPassword(encodedPassword);
 
         identityManager.validateCredentials(badUserName);
 
@@ -93,10 +93,10 @@ public class PasswordCredentialTestCase extends AbstractIdentityManagerTestCase 
 
         UsernamePasswordCredentials badPassword = new UsernamePasswordCredentials();
 
-        plainTextPassword = new PlainTextPassword("bad_password".toCharArray());
+        encodedPassword = new EncodedPassword("bad_password".toCharArray());
         
         badPassword.setUsername(user.getId());
-        badPassword.setPassword(plainTextPassword);
+        badPassword.setPassword(encodedPassword);
 
         identityManager.validateCredentials(badPassword);
 
@@ -115,17 +115,17 @@ public class PasswordCredentialTestCase extends AbstractIdentityManagerTestCase 
     public void testExpiration() throws Exception {
         IdentityManager identityManager = getIdentityManager();
         User user = loadOrCreateUser("someUser", true);
-        PlainTextPassword plainTextPassword = new PlainTextPassword("updated_password".toCharArray());
+        EncodedPassword encodedPassword = new EncodedPassword("updated_password".toCharArray());
 
         Calendar expirationDate = Calendar.getInstance();
         
         expirationDate.add(Calendar.MINUTE, -1);
         
-        identityManager.updateCredential(user, plainTextPassword, new Date(), expirationDate.getTime());
+        identityManager.updateCredential(user, encodedPassword, new Date(), expirationDate.getTime());
         UsernamePasswordCredentials credential = new UsernamePasswordCredentials();
 
         credential.setUsername(user.getId());
-        credential.setPassword(plainTextPassword);
+        credential.setPassword(encodedPassword);
 
         identityManager.validateCredentials(credential);
 


### PR DESCRIPTION
Following the discussions on security-dev (http://lists.jboss.org/pipermail/security-dev/2013-January/000652.html) let's refactor it for the sake of our sanity.
