### PR TITLE
Return request.getSession().setAttribute("PRINCIPAL", facebookPrincipal) back. Make method handleAuthenticationResponse public, so applications, which don't need principal in httpSession to call it directly

### DIFF
--- a/social/src/main/java/org/picketlink/social/standalone/fb/FacebookProcessor.java
+++ b/social/src/main/java/org/picketlink/social/standalone/fb/FacebookProcessor.java
@@ -134,15 +134,17 @@ public class FacebookProcessor {
         }
     }
 
-    public Principal getPrincipal(HttpServletRequest request, HttpServletResponse response) { 
+    public Principal getPrincipal(HttpServletRequest request, HttpServletResponse response) {
         Principal facebookPrincipal = handleAuthenticationResponse(request, response);
         if (facebookPrincipal == null)
             return null;
 
+        request.getSession().setAttribute("PRINCIPAL", facebookPrincipal);
+
         return facebookPrincipal;
     }
 
-    protected Principal handleAuthenticationResponse(HttpServletRequest request, HttpServletResponse response) {
+    public Principal handleAuthenticationResponse(HttpServletRequest request, HttpServletResponse response) {
         String error = request.getParameter(OAuthConstants.ERROR_PARAMETER);
         if (error != null) {
             throw new RuntimeException("error:" + error);


### PR DESCRIPTION
1) Revert removal of principal from httpSession in request.getSession().setAttribute("PRINCIPAL", facebookPrincipal) . 

2) Make method handleAuthenticationResponse public, so applications, which don't need principal in httpSession, can use it directly
