### PR TITLE
Upgrade maven-compiler-plugin and get rid of NPE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,7 +195,7 @@
            <plugin>
               <groupId>org.apache.maven.plugins</groupId>
               <artifactId>maven-compiler-plugin</artifactId>
-              <version>2.5.1</version>
+              <version>3.1</version>
               <configuration>
                  <source>1.6</source>
                  <target>1.6</target>


### PR DESCRIPTION
Hi guys, looks like there's a bug into maven-compiler 2.5. To reproduce the issue, just grab the sources from the repo and run: mvn clean install -DskipTests=true

It will raise:  https://gist.github.com/abstractj/fdc475e405ba9619b996
