### PR TITLE
PLINK-258 PasswordCredentialEncoder.generateSalt() always generate same value 

### DIFF
--- a/modules/idm/api/src/main/java/org/picketlink/idm/IDMLogger.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/IDMLogger.java
@@ -52,4 +52,21 @@ public interface IDMLogger extends BasicLogger {
     @Message(id = 1101, value = "Working directory [%s] is marked to be always created. All your existing data will be lost.")
     void fileConfigAlwaysCreateWorkingDir(String path);
 
+    // SecureRandom logging messages. Ids 1200-1299
+    @LogMessage(level = Level.INFO)
+    @Message(id = 1200, value = "Start initialization of SecureRandom")
+    void startSecureRandomInitialization();
+
+    @LogMessage(level = Level.INFO)
+    @Message(id = 1201, value = "SecureRandom initialized successfully")
+    void secureRandomInitialized();
+
+    @LogMessage(level = Level.DEBUG)
+    @Message(id = 1202, value = "SecureRandom re-initialized with new seed")
+    void secureRandomReinitialized();
+
+    @LogMessage(level = Level.DEBUG)
+    @Message(id = 1203, value = "Will use secureRandomProvider [%s].")
+    void usedSecureRandomProvider(String secureRandomProvider);
+
 }

--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/AbstractIdentityStoreConfiguration.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/AbstractIdentityStoreConfiguration.java
@@ -28,6 +28,7 @@ import org.picketlink.idm.spi.IdentityStore;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -81,7 +82,8 @@ public abstract class AbstractIdentityStoreConfiguration implements IdentityStor
         this.unsupportedTypes = unmodifiableMap(unsupportedTypes);
         this.contextInitializers = unmodifiableList(contextInitializers);
         this.credentialHandlers = unmodifiableSet(credentialHandlers);
-        this.credentialHandlerProperties = unmodifiableMap(credentialHandlerProperties);
+        // Not unmodifiable, so that some CredentialHandlers could possibly add more properties during it's initialization
+        this.credentialHandlerProperties = new HashMap<String, Object>(credentialHandlerProperties);
         this.supportsAttribute = supportsAttribute;
     }
 

--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/IdentityStoreConfigurationBuilder.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/IdentityStoreConfigurationBuilder.java
@@ -23,6 +23,8 @@
 package org.picketlink.idm.config;
 
 import org.picketlink.idm.credential.handler.CredentialHandler;
+import org.picketlink.idm.credential.handler.PasswordCredentialHandler;
+import org.picketlink.idm.credential.random.SimpleSecureRandomProvider;
 import org.picketlink.idm.model.AttributedType;
 import org.picketlink.idm.model.IdentityType;
 import org.picketlink.idm.model.Partition;
@@ -194,6 +196,16 @@ public abstract class IdentityStoreConfigurationBuilder<T extends IdentityStoreC
      */
     public S setCredentialHandlerProperty(String propertyName, Object value) {
         this.credentialHandlerProperties.put(propertyName, value);
+        return (S) this;
+    }
+
+    /**
+     * <p>Sets simple secure random provider to credential handler properties. Useful just for testing purposes</p>
+     *
+     * @return
+     */
+    public S simpleSecureRandomProvider() {
+        this.setCredentialHandlerProperty(PasswordCredentialHandler.SECURE_RANDOM_PROVIDER, new SimpleSecureRandomProvider());
         return (S) this;
     }
 

--- a/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/AutoReseedSecureRandomProvider.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/AutoReseedSecureRandomProvider.java
@@ -1,0 +1,109 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.picketlink.idm.credential.random;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
+
+import org.picketlink.idm.IdentityManagementException;
+import static org.picketlink.idm.IDMLogger.*;
+
+/**
+ * <p>SecureRandomProvider initialized with random seed. It's also periodically reseeding itself, so the seed can't be guessed.</p>
+ *
+ * <p>It's good for production environment, however may not be so good for testing, as initialization of SecureRandom could be slow.
+ * The initialization is performed in separate thread, so it could be started even before first random number is obtained and it's not
+ * blocking caller</p>
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class AutoReseedSecureRandomProvider implements SecureRandomProvider {
+
+    private AtomicReference<SecureRandom> reference = new AtomicReference<SecureRandom>();
+
+    private volatile boolean started = false;
+    private final CountDownLatch initializationLatch = new CountDownLatch(1);
+
+    // 5 minutes by default
+    private static final int DEFAULT_RESEED_INTERVAL = 1000 * 60 *5;
+
+    @Override
+    public SecureRandom getSecureRandom() {
+        if (!this.started) {
+            throw new IllegalStateException("AutoReseedSecureRandomProvider needs to be started before it's used");
+        }
+
+        try {
+            initializationLatch.await();
+        } catch (InterruptedException ie) {
+            Thread.currentThread().interrupt();
+        }
+
+        return reference.get();
+    }
+
+    public void start() {
+        Thread t = new Thread(new Runnable() {
+
+            @Override
+            public void run() {
+                LOGGER.startSecureRandomInitialization();
+                SecureRandom secureRandom = initSecureRandom();
+                reference.set(secureRandom);
+                LOGGER.secureRandomInitialized();
+
+                initializationLatch.countDown();
+
+                // Re-init provider periodically
+                while (true) {
+                    try {
+                        Thread.sleep(DEFAULT_RESEED_INTERVAL);
+                    } catch (InterruptedException ie) {
+                        Thread.currentThread().interrupt();
+                    }
+                    secureRandom = initSecureRandom();
+                    reference.set(secureRandom);
+                    LOGGER.secureRandomReinitialized();
+                }
+            }
+
+        }, AutoReseedSecureRandomProvider.class.getSimpleName() + " worker");
+
+        // Make a daemon so that the VM can be shut down before it completes
+        t.setDaemon(true);
+        t.start();
+
+        this.started = true;
+    }
+
+    protected SecureRandom initSecureRandom() {
+        try {
+            SecureRandom pseudoRandom = SecureRandom.getInstance(DEFAULT_SALT_ALGORITHM);
+            // Force seed initialization
+            pseudoRandom.nextLong();
+            return pseudoRandom;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IdentityManagementException("Error getting SecureRandom instance: " + DEFAULT_SALT_ALGORITHM, e);
+        }
+    }
+
+
+}

--- a/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/SecureRandomProvider.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/SecureRandomProvider.java
@@ -1,0 +1,37 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.picketlink.idm.credential.random;
+
+import java.security.SecureRandom;
+
+/**
+ * Provides initialized and seeded instance of SecureRandom
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public interface SecureRandomProvider {
+
+    String DEFAULT_SALT_ALGORITHM = "SHA1PRNG";
+
+    /**
+     * @return initialized and seeded instance of SecureRandom
+     */
+    SecureRandom getSecureRandom();
+
+}

--- a/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/SimpleSecureRandomProvider.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/credential/random/SimpleSecureRandomProvider.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.picketlink.idm.credential.random;
+
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+
+import org.picketlink.idm.IdentityManagementException;
+
+/**
+ * Simple {@link SecureRandomProvider}, which provides {@link SecureRandom} with static seed.
+ * WARN: It's predictable and not secure. It should be used just for testing purposes (unit test etc) as initialization is always fast
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class SimpleSecureRandomProvider implements SecureRandomProvider {
+
+    private final SecureRandom secureRandom;
+
+    public SimpleSecureRandomProvider() {
+        try {
+            SecureRandom pseudoRandom = SecureRandom.getInstance(DEFAULT_SALT_ALGORITHM);
+            pseudoRandom.setSeed(1024);
+            this.secureRandom = pseudoRandom;
+        } catch (NoSuchAlgorithmException e) {
+            throw new IdentityManagementException("Error getting SecureRandom instance: " + DEFAULT_SALT_ALGORITHM, e);
+        }
+    }
+
+    @Override
+    public SecureRandom getSecureRandom() {
+        return secureRandom;
+    }
+
+}

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/other/shane/ShanesBigSanityCheckTestCase.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/other/shane/ShanesBigSanityCheckTestCase.java
@@ -81,7 +81,8 @@ public class ShanesBigSanityCheckTestCase {
                         }
                     })
                     .addCredentialHandler(UserPasswordCredentialHandler.class)
-                    .supportAllFeatures();
+                    .supportAllFeatures()
+                    .simpleSecureRandomProvider();
 
         PartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/partition/MultiplePartitionTestCase.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/partition/MultiplePartitionTestCase.java
@@ -205,7 +205,8 @@ public class MultiplePartitionTestCase {
                                 return entityManager;
                             }
                         })
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         return new DefaultPartitionManager(builder.buildAll());
     }

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/performance/FileIdentityStoreLoadUsersJMeterTest.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/performance/FileIdentityStoreLoadUsersJMeterTest.java
@@ -133,7 +133,8 @@ public class FileIdentityStoreLoadUsersJMeterTest extends AbstractJavaSamplerCli
                         .preserveState(false)
                         .asyncWrite(true)
                         .asyncWriteThreadPool(20)
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         DefaultPartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/performance/JPAIdentityStoreLoadUsersJMeterTest.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/performance/JPAIdentityStoreLoadUsersJMeterTest.java
@@ -194,7 +194,8 @@ public class JPAIdentityStoreLoadUsersJMeterTest extends AbstractJavaSamplerClie
                                 return entityManager.get();
                             }
                         })
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
             DefaultPartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/FileStoreConfigurationTester.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/FileStoreConfigurationTester.java
@@ -37,7 +37,8 @@ public class FileStoreConfigurationTester implements IdentityConfigurationTester
                 .stores()
                     .file()
                     .preserveState(false)
-                    .supportAllFeatures();
+                    .supportAllFeatures()
+                    .simpleSecureRandomProvider();
 
         DefaultPartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/JPAStoreComplexSchemaConfigurationTester.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/JPAStoreComplexSchemaConfigurationTester.java
@@ -84,7 +84,8 @@ public class JPAStoreComplexSchemaConfigurationTester implements IdentityConfigu
                         return entityManager;
                     }
                 })
-                .supportAllFeatures();
+                .supportAllFeatures()
+                .simpleSecureRandomProvider();
 
         return new DefaultPartitionManager(builder.buildAll());
     }

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/JPAStoreConfigurationTester.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/JPAStoreConfigurationTester.java
@@ -83,7 +83,8 @@ public class JPAStoreConfigurationTester implements IdentityConfigurationTester 
                                 return entityManager;
                             }
                         })
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         DefaultPartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/SingleConfigLDAPJPAStoreConfigurationTester.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/testers/SingleConfigLDAPJPAStoreConfigurationTester.java
@@ -15,6 +15,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 package org.picketlink.test.idm.testers;
 
 import org.picketlink.idm.config.IdentityConfigurationBuilder;

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/usecases/FileStorePreservingStateTestCase.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/usecases/FileStorePreservingStateTestCase.java
@@ -31,7 +31,8 @@ public class FileStorePreservingStateTestCase {
                 .stores()
                     .file()
                         .workingDirectory("/tmp/teste")
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         PartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
 
@@ -67,7 +68,8 @@ public class FileStorePreservingStateTestCase {
                     .file()
                         .preserveState(true)
                         .workingDirectory("/tmp/teste")
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         partitionManager = new DefaultPartitionManager(builder.buildAll());
 
@@ -95,7 +97,8 @@ public class FileStorePreservingStateTestCase {
                     .file()
                         .preserveState(true)
                         .workingDirectory("/tmp/teste")
-                        .supportAllFeatures();
+                        .supportAllFeatures()
+                        .simpleSecureRandomProvider();
 
         partitionManager = new DefaultPartitionManager(builder.buildAll());
 

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/usecases/RealSecureRandomProviderTestCase.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/usecases/RealSecureRandomProviderTestCase.java
@@ -1,0 +1,82 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.picketlink.test.idm.usecases;
+
+import org.junit.Test;
+import org.picketlink.idm.IdentityManager;
+import org.picketlink.idm.config.IdentityConfigurationBuilder;
+import org.picketlink.idm.credential.Credentials;
+import org.picketlink.idm.credential.Password;
+import org.picketlink.idm.credential.UsernamePasswordCredentials;
+import org.picketlink.idm.internal.DefaultPartitionManager;
+import org.picketlink.idm.model.basic.Realm;
+import org.picketlink.idm.model.basic.User;
+
+import static org.junit.Assert.*;
+
+/**
+ * <p>Test case of {@link org.picketlink.idm.credential.random.AutoReseedSecureRandomProvider} used as SecureRandomProvider for
+ * {@link org.picketlink.idm.credential.handler.PasswordCredentialHandler}.</p>
+ *
+ * <p>Other unit tests are using simpleSecureRandomProvider to not block the execution of unit tests</p>
+ *
+ * @author <a href="mailto:mposolda@redhat.com">Marek Posolda</a>
+ */
+public class RealSecureRandomProviderTestCase {
+
+    @Test
+    public void testSecureRandomProvider() {
+        IdentityConfigurationBuilder builder = new IdentityConfigurationBuilder();
+
+        // Don't add simpleSecureRandomProvider, which means that PasswordCredentialHandler will use AutoReseedSecureRandomProvider
+        builder
+            .named("simple-file-store")
+                .stores()
+                    .file()
+                    .preserveState(false)
+                    .supportAllFeatures();
+
+        DefaultPartitionManager partitionManager = new DefaultPartitionManager(builder.buildAll());
+
+        if (partitionManager.getPartition(Realm.class, Realm.DEFAULT_REALM) == null) {
+            partitionManager.add(new Realm(Realm.DEFAULT_REALM));
+        }
+
+        User john = new User("john");
+        User mary = new User("mary");
+        IdentityManager identityManager = partitionManager.createIdentityManager();
+        identityManager.add(john);
+        identityManager.add(mary);
+        identityManager.updateCredential(john, new Password("johnpass"));
+        identityManager.updateCredential(mary, new Password("marypass"));
+
+        UsernamePasswordCredentials valid1 = new UsernamePasswordCredentials("john", new Password("johnpass"));
+        UsernamePasswordCredentials valid2 = new UsernamePasswordCredentials("mary", new Password("marypass"));
+        UsernamePasswordCredentials invalid1 = new UsernamePasswordCredentials("mary", new Password("johnpass"));
+        UsernamePasswordCredentials invalid2 = new UsernamePasswordCredentials("john", new Password("marypass"));
+        identityManager.validateCredentials(valid1);
+        identityManager.validateCredentials(valid2);
+        identityManager.validateCredentials(invalid1);
+        identityManager.validateCredentials(invalid2);
+        assertEquals(Credentials.Status.VALID, valid1.getStatus());
+        assertEquals(Credentials.Status.VALID, valid2.getStatus());
+        assertEquals(Credentials.Status.INVALID, invalid1.getStatus());
+        assertEquals(Credentials.Status.INVALID, invalid2.getStatus());
+    }
+}

--- a/modules/idm/tests/src/test/resources/config/embedded-file-config.xml
+++ b/modules/idm/tests/src/test/resources/config/embedded-file-config.xml
@@ -9,6 +9,7 @@
           <preserveState value="false" />
           <supportGlobalRelationship value="org.picketlink.idm.model.Relationship" />
           <supportAllFeatures />
+          <simpleSecureRandomProvider />
         </file>
       </stores>
     </named>

--- a/modules/idm/tests/src/test/resources/config/embedded-jpa-config.xml
+++ b/modules/idm/tests/src/test/resources/config/embedded-jpa-config.xml
@@ -22,6 +22,7 @@
               value14="org.picketlink.test.idm.partition.CustomPartitionEntity" />
           <supportGlobalRelationship value="org.picketlink.idm.model.Relationship" />
           <supportAllFeatures />
+          <simpleSecureRandomProvider />
           <!-- JPAContextInitializer needs to be added programmatically later -->
         </jpa>
       </stores>


### PR DESCRIPTION
To address the issue, I've added SecureRandomProvider interface and two implementations

1) AutoReseedSecureRandomProvider implementation, which returns SecureRandom generated with random seed. It also periodically replaces SecureRandom with new instance after each 5 minutes, so that it's not possible to guess seed value from previously generated salts (See http://www.cigital.com/justice-league-blog/2009/08/14/proper-use-of-javas-securerandom/ for background info). 

This implementation should be safe, however random generation of seed is platform dependent and could be sometimes slow on some platforms (It's blocking operation, which initializes seed from system data). For this purpose, the generation of SecureRandom is asynchronously done in separate thread (we have something like this in GateIn portal as well), but it may still block the caller if he use getSecureRandom() before the initialization is done.

2) SimpleSecureRandomProvider implementation, which is quite similar to current implementation, so the seed is not random and is predictable (despite the fact that it's using same instance of SecureRandom provider, so it won't always generate same salt like currently). This implementation is not secure, however is fast, so it should be good for unit test purposes

I've changed PasswordCredentialHandler to read SecureRandomProvider from credentialHandlerProperties map and use secure version AutoReseedSecureRandomProvider by default. 
I've also changed almost all unit tests to use SimpleSecureRandomProvider, so they are not blocked by possibly slow initialization of SecureRandom. I've just added one new unit test "RealSecureRandomProviderTestCase" to use secure AutoReseedSecureRandomProvider.

I've also changed AbstractIdentityStoreConfiguration.credentialHandlerProperties to not be unmodifiable map, so that if PasswordCredentialHandler needs to use AutoReseedSecureRandomProvider, it will add it back to the map, so it could be shared with next CredentialHandler instances (like TOTPCredentialHandler)

Let me know if you're happy with this approach or if you prefer to change something or do it differently 
