### PR TITLE
Removing the initConfig method from the AbstractIdentityStoreConfiguration class

### DIFF
--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/AbstractIdentityStoreConfiguration.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/AbstractIdentityStoreConfiguration.java
@@ -90,7 +90,6 @@ public abstract class AbstractIdentityStoreConfiguration implements IdentityStor
 
     @Override
     public final void init() throws SecurityConfigurationException {
-        initConfig();
 
         if (LOGGER.isDebugEnabled()) {
             LOGGER.debugf("FeatureSet for %s", this);
@@ -113,8 +112,6 @@ public abstract class AbstractIdentityStoreConfiguration implements IdentityStor
             LOGGER.debug("]");
         }
     }
-
-    protected abstract void initConfig();
 
     @Override
     public void addContextInitializer(ContextInitializer contextInitializer) {

--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/FileIdentityStoreConfiguration.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/FileIdentityStoreConfiguration.java
@@ -59,10 +59,6 @@ public class FileIdentityStoreConfiguration extends AbstractIdentityStoreConfigu
         this.asyncThreadPool = asyncWriteThreadPool;
     }
 
-    @Override
-    protected void initConfig() throws SecurityConfigurationException {
-    }
-
     public String getWorkingDir() {
         return this.workingDir;
     }

--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/JPAIdentityStoreConfiguration.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/JPAIdentityStoreConfiguration.java
@@ -55,9 +55,6 @@ public class JPAIdentityStoreConfiguration extends AbstractIdentityStoreConfigur
         this.entityTypes = entityTypes;
     }
 
-    @Override
-    protected void initConfig() {  }
-
     public Set<Class<?>> getEntityTypes() {
         return this.entityTypes;
     }

--- a/modules/idm/api/src/main/java/org/picketlink/idm/config/LDAPIdentityStoreConfiguration.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/config/LDAPIdentityStoreConfiguration.java
@@ -71,10 +71,6 @@ public class LDAPIdentityStoreConfiguration extends AbstractIdentityStoreConfigu
         this.mappingConfig = mappingConfig;
     }
 
-    @Override
-    protected void initConfig() throws SecurityConfigurationException {
-    }
-
     public String getStandardAttributesFileName() {
         return this.standardAttributesFileName;
     }

--- a/modules/idm/tests/src/test/java/org/picketlink/test/idm/config/CustomIdentityStoreTestCase.java
+++ b/modules/idm/tests/src/test/java/org/picketlink/test/idm/config/CustomIdentityStoreTestCase.java
@@ -130,11 +130,6 @@ public class CustomIdentityStoreTestCase {
         }
 
         @Override
-        protected void initConfig() {
-
-        }
-
-        @Override
         public Class<? extends IdentityStore> getIdentityStoreType() {
             return MyIdentityStore.class;
         }


### PR DESCRIPTION
It is currently unused by all provided subclasses.
