### PR TITLE
[BZ#1020846] Fixing NPE problem, Using service name as truststore alias for the certificate retrieval.

### DIFF
--- a/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/PicketLinkSTSConfiguration.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/PicketLinkSTSConfiguration.java
@@ -344,7 +344,7 @@ public class PicketLinkSTSConfiguration implements STSConfiguration {
 
                 // if there was no truststore alias or no PKC under that alias, use the KeyProvider mapping.
                 if (x509 == null) {
-                    Certificate cer = this.trustManager.getCertificate(provider.getTruststoreAlias());
+                    Certificate cer = this.trustManager.getCertificate(serviceName);
 
                     if (cer instanceof X509Certificate) {
                         x509 = (X509Certificate) cer;


### PR DESCRIPTION
Porting fix from PL 2.1.9 (EAP 6.2).
