### PR TITLE
Correct documentation of SupportSignatures

### DIFF
--- a/docs/src/main/docbook/en-US/picketlink-federation.xml
+++ b/docs/src/main/docbook/en-US/picketlink-federation.xml
@@ -1620,7 +1620,7 @@
                       <row>
                         <entry>
                           <para>
-                            SupportsSignature
+                            SupportsSignatures
                             
                           </para>
                         </entry>


### PR DESCRIPTION
Picketlink has the option SupportSignatures. But the documentation says SupportSignature
