### PR TITLE
PRODMGT-547 - added a new attribute 'EndpointRegEx' to <ServiceProvider/> tag to allow...

### DIFF
--- a/modules/common/src/main/java/org/picketlink/common/DefaultPicketLinkLogger.java
+++ b/modules/common/src/main/java/org/picketlink/common/DefaultPicketLinkLogger.java
@@ -371,7 +371,7 @@ public class DefaultPicketLinkLogger implements PicketLinkLogger {
      */
     @Override
     public ParsingException parserRequiredAttribute(String string) {
-        return new ParsingException(REQD_ATTRIBUTE + "AssertionID");
+        return new ParsingException(REQD_ATTRIBUTE + string);
     }
 
     /*

--- a/modules/config/src/main/java/org/picketlink/config/federation/STSType.java
+++ b/modules/config/src/main/java/org/picketlink/config/federation/STSType.java
@@ -296,4 +296,5 @@ public class STSType {
             return clockSkew;
         }
     }
+
 }

--- a/modules/config/src/main/java/org/picketlink/config/federation/ServiceProviderType.java
+++ b/modules/config/src/main/java/org/picketlink/config/federation/ServiceProviderType.java
@@ -53,6 +53,8 @@ public class ServiceProviderType {
 
     protected String truststoreAlias;
 
+    private String endpointRegEx;
+
     /**
      * Gets the value of the endpoint property.
      *
@@ -113,4 +115,11 @@ public class ServiceProviderType {
         this.truststoreAlias = value;
     }
 
+    public void setEndpointRegEx(String endpointRegEx) {
+        this.endpointRegEx = endpointRegEx;
+    }
+
+    public String getEndpointRegEx() {
+        return endpointRegEx;
+    }
 }

--- a/modules/config/src/main/java/org/picketlink/config/federation/parsers/STSConfigParser.java
+++ b/modules/config/src/main/java/org/picketlink/config/federation/parsers/STSConfigParser.java
@@ -109,6 +109,8 @@ public class STSConfigParser extends AbstractParser {
 
     private static final String ENDPOINT_ATTRIB = "Endpoint";
 
+    private static final String ENDPOINT_REGEX_ATTRIB = "EndpointRegEx";
+
     private static final String TRUSTSTORE_ALIAS_ATTRIB = "TruststoreAlias";
 
     /*
@@ -526,6 +528,10 @@ public class STSConfigParser extends AbstractParser {
                 attribute = subEvent.getAttributeByName(attributeQName);
                 if (attribute != null)
                     serviceProvider.setEndpoint(StaxParserUtil.getAttributeValue(attribute));
+                attributeQName = new QName("", ENDPOINT_REGEX_ATTRIB);
+                attribute = subEvent.getAttributeByName(attributeQName);
+                if (attribute != null)
+                    serviceProvider.setEndpointRegEx(StaxParserUtil.getAttributeValue(attribute));
                 attributeQName = new QName("", TRUSTSTORE_ALIAS_ATTRIB);
                 attribute = subEvent.getAttributeByName(attributeQName);
                 if (attribute != null)

--- a/modules/federation/src/test/java/org/picketlink/test/identity/federation/core/config/ConfigUnitTestCase.java
+++ b/modules/federation/src/test/java/org/picketlink/test/identity/federation/core/config/ConfigUnitTestCase.java
@@ -190,6 +190,61 @@ public class ConfigUnitTestCase {
         assertEquals("2.2", "2.2", k2.getValue());
     }
 
+    @Test
+    public void test06() throws Exception {
+          ClassLoader tcl = Thread.currentThread().getContextClassLoader();
+          InputStream is = tcl.getResourceAsStream(this.config + "6.xml");
+          assertNotNull("Inputstream not null for config file:" + this.config + "4.xml", is);
+
+          STSConfigParser parser = new STSConfigParser();
+
+          Object object = parser.parse(is);
+          assertNotNull("Found a null STS configuration", object);
+
+          STSType stsType = (STSType) object;
+          // general STS configurations.
+          assertEquals("Unexpected STS name", "Test STS", stsType.getSTSName());
+          assertEquals("Unexpected token timeout value", 7200, stsType.getTokenTimeout());
+          assertTrue("Encryption of tokens should have been enabled", stsType.isEncryptToken());
+          // we don't verify all values of the key provider config as it has been done in the other test scenarios.
+          assertNotNull("Unexpected null key provider", stsType.getKeyProvider());
+          // request handler and configurations based on the token type.
+          assertEquals("Unexpected request handler class", "org.picketlink.identity.federation.wstrust.Handler",
+                  stsType.getRequestHandler());
+          // configuration of the token providers.
+          TokenProvidersType tokenProviders = stsType.getTokenProviders();
+          assertNotNull("Unexpected null list of token providers", tokenProviders);
+          assertEquals("Unexpected number of token providers", 1, tokenProviders.getTokenProvider().size());
+          TokenProviderType tokenProvider = tokenProviders.getTokenProvider().get(0);
+          assertNotNull("Unexpected null token provider", tokenProvider);
+          assertEquals("Unexpected provider class name", "org.jboss.SpecialTokenProvider", tokenProvider.getProviderClass());
+          assertEquals("Unexpected token type", "specialToken", tokenProvider.getTokenType());
+          assertEquals("Unexpected token element name", "SpecialToken", tokenProvider.getTokenElement());
+          assertEquals("Unexpected token namespace", "http://www.tokens.org", tokenProvider.getTokenElementNS());
+          List<KeyValueType> properties = tokenProvider.getProperty();
+          assertEquals("Invalid number of properties", 2, properties.size());
+          // configuration of the service providers with RegEx endpoints
+          ServiceProvidersType serviceProviders = stsType.getServiceProviders();
+          assertNotNull("Unexpected null list of service providers", serviceProviders);
+          assertEquals("Unexpected number of service providers", 2, serviceProviders.getServiceProvider().size());
+          ServiceProviderType serviceProviderRegEx = serviceProviders.getServiceProvider().get(0);
+          assertNotNull("Unexpected null service provider", serviceProviderRegEx);
+          assertEquals("Unexpected provider endpoint", "http://provider.endpoint/provider", serviceProviderRegEx.getEndpoint());
+          assertEquals("Unexpected truststore alias", "providerAlias", serviceProviderRegEx.getTruststoreAlias());
+          assertEquals("Unexpected token type", "specialToken", serviceProviderRegEx.getTokenType());
+
+
+          // configuration of the service providers.
+          assertNotNull("Unexpected null list of service providers", serviceProviders);
+          assertEquals("Unexpected number of service providers", 2, serviceProviders.getServiceProvider().size());
+          ServiceProviderType serviceProvider = serviceProviders.getServiceProvider().get(1);
+          assertNotNull("Unexpected null service provider regex", serviceProvider);
+          assertEquals("Unexpected provider endpoint regex", "http://provider.endpoint/provider[A-Z]", serviceProvider.getEndpointRegEx());
+          assertEquals("Unexpected truststore alias regex", "providerAliasRegEx", serviceProvider.getTruststoreAlias());
+          assertEquals("Unexpected token type regex", "specialTokenRegEx", serviceProvider.getTokenType());
+      }
+
+
     private Object unmarshall(String configFile) throws Exception {
 
         /*

--- a/modules/federation/src/test/resources/config/test-config-6.xml
+++ b/modules/federation/src/test/resources/config/test-config-6.xml
@@ -1,0 +1,27 @@
+<PicketLinkSTS xmlns="urn:picketlink:identity-federation:config:1.0"
+               STSName="Test STS" TokenTimeout="7200" EncryptToken="true">
+  <KeyProvider ClassName="SomeClass">
+    <ValidatingAlias Key="localhost" Value="localhostalias"/>
+    <ValidatingAlias Key="jboss.com" Value="jbossalias"/>
+    <SigningAlias>issueralias</SigningAlias>
+  </KeyProvider>
+  <RequestHandler>org.picketlink.identity.federation.wstrust.Handler</RequestHandler>
+  <TokenProviders>
+    <TokenProvider
+            ProviderClass="org.jboss.SpecialTokenProvider"
+            TokenType="specialToken"
+            TokenElement="SpecialToken"
+            TokenElementNS="http://www.tokens.org">
+      <Property Key="Property1" Value="Value1"/>
+      <Property Key="Property2" Value="Value2"/>
+    </TokenProvider>
+  </TokenProviders>
+  <ServiceProviders>
+    <ServiceProvider Endpoint="http://provider.endpoint/provider"
+                     TokenType="specialToken"
+                     TruststoreAlias="providerAlias"/>
+    <ServiceProvider EndpointRegEx="http://provider.endpoint/provider[A-Z]"
+                     TokenType="specialTokenRegEx"
+                     TruststoreAlias="providerAliasRegEx"/>
+  </ServiceProviders>
+</PicketLinkSTS>

--- a/modules/federation/src/test/resources/sts/picketlink-sts.xml
+++ b/modules/federation/src/test/resources/sts/picketlink-sts.xml
@@ -32,5 +32,10 @@
     <ServiceProvider Endpoint="http://services.testcorp.org/provider2"
                      TokenType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"
                      TruststoreAlias="service2"/>
+    <ServiceProvider EndpointRegEx="^http://services\.testcorptwo\.org.*"
+                     TokenType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0"
+                     TruststoreAlias="service2"/>
+    <ServiceProvider EndpointRegEx="^http://services\.testcorpone\.org.*" TokenType="http://www.tokens.org/SpecialToken"
+                     TruststoreAlias="service1"/>
   </ServiceProviders>
 </PicketLinkSTS>


### PR DESCRIPTION
for PRODMGT-547 we introduced a new attribute:

EndpointRegEx
eg:

`<ServiceProvider EndpointRegEx="^http://services\.testcorptwo\.org.*"
   TokenType="http://docs.oasis-open.org/wss/oasis-wss-saml-token-profile-1.1#SAMLV2.0" 
   TruststoreAlias="service2"/>`

this allows to sue regular expressions as endpoints.
