### PR TITLE
[no-issue] Add SAML_BINDING constant to be used to save the request bind...

### DIFF
--- a/modules/common/src/main/java/org/picketlink/common/constants/GeneralConstants.java
+++ b/modules/common/src/main/java/org/picketlink/common/constants/GeneralConstants.java
@@ -144,4 +144,7 @@ public interface GeneralConstants {
 
     String AUTHN_CONTEXT_CLASSES = "AUTHN_CONTEXT_CLASSES";
     String REQUESTED_AUTHN_CONTEXT_COMPARISON = "REQUESTED_AUTHN_CONTEXT_COMPARISON";
+
+    /** SamlRequest binding type: GET/POST as retrieved by the first request from SP to IDP  **/
+    String SAML_BINDING = "SAML_BINDING";
 }

--- a/modules/federation/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/web/util/IDPWebRequestUtil.java
@@ -87,6 +87,18 @@ public class IDPWebRequestUtil {
         this.postProfile = "POST".equals(request.getMethod());
     }
 
+    public IDPWebRequestUtil(String samlBinding, HttpServletRequest request, IDPType idp, TrustKeyManager keym) {
+        this.idpConfiguration = idp;
+        this.keyManager = keym;
+        if(samlBinding !=null){
+            this.redirectProfile = "GET".equals(samlBinding);
+            this.postProfile = "POST".equals(samlBinding);
+        } else {
+            this.redirectProfile = "GET".equals(request.getMethod());
+            this.postProfile = "POST".equals(request.getMethod());
+        }
+    }
+
     public String getCanonicalizationMethod() {
         return canonicalizationMethod;
     }


### PR DESCRIPTION
...ing type

Add constructor to IDPWebRequestUtil that uses the retreived SAML_BINDING and if not available the request.getMethod() to determine is the saml request was a bind or a post.
