### PR TITLE
PLINK-408: Allow built in schemes to be overridden in AuthenticationFilter

### DIFF
--- a/modules/base/api/src/main/java/org/picketlink/authentication/web/BasicAuthenticationScheme.java
+++ b/modules/base/api/src/main/java/org/picketlink/authentication/web/BasicAuthenticationScheme.java
@@ -23,6 +23,7 @@
 package org.picketlink.authentication.web;
 
 import java.io.IOException;
+
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -43,7 +44,8 @@ public class BasicAuthenticationScheme implements HTTPAuthenticationScheme {
 
     private String realm = DEFAULT_REALM_NAME;
 
-    public BasicAuthenticationScheme(FilterConfig config) {
+    @Override
+    public void initialize(FilterConfig config) {
         String providedRealm = config.getInitParameter(REALM_NAME_INIT_PARAM);
 
         if (providedRealm != null) {

--- a/modules/base/api/src/main/java/org/picketlink/authentication/web/ClientCertAuthenticationScheme.java
+++ b/modules/base/api/src/main/java/org/picketlink/authentication/web/ClientCertAuthenticationScheme.java
@@ -19,9 +19,11 @@ package org.picketlink.authentication.web;
 
 import java.io.IOException;
 import java.security.cert.X509Certificate;
+
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
 import org.picketlink.credential.DefaultLoginCredentials;
 import org.picketlink.idm.credential.X509CertificateCredentials;
 
@@ -37,7 +39,8 @@ public class ClientCertAuthenticationScheme implements HTTPAuthenticationScheme 
 
     public static final String X509_CLIENT_CERT_REQUEST_ATTRIBUTE = "javax.servlet.request.X509Certificate";
 
-    public ClientCertAuthenticationScheme(FilterConfig config) {
+    @Override
+    public void initialize(FilterConfig config) {
 
     }
 

--- a/modules/base/api/src/main/java/org/picketlink/authentication/web/DigestAuthenticationScheme.java
+++ b/modules/base/api/src/main/java/org/picketlink/authentication/web/DigestAuthenticationScheme.java
@@ -24,6 +24,7 @@ package org.picketlink.authentication.web;
 
 import java.io.IOException;
 import java.util.Timer;
+
 import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -45,11 +46,12 @@ public class DigestAuthenticationScheme implements HTTPAuthenticationScheme {
 
     private final Timer nonceCleanupTimer = new Timer("PicketLink_Digest_Nonce_Cache_Cleanup");
 
-    private NonceCache nonceCache = new NonceCache();
+    private final NonceCache nonceCache = new NonceCache();
 
     private String realm = DEFAULT_REALM_NAME;
 
-    public DigestAuthenticationScheme(FilterConfig config) {
+    @Override
+    public void initialize(FilterConfig config) {
         String providedRealm = config.getInitParameter(REALM_NAME_INIT_PARAM);
 
         if (providedRealm != null) {
@@ -57,7 +59,7 @@ public class DigestAuthenticationScheme implements HTTPAuthenticationScheme {
         }
 
         this.nonceCleanupTimer
-                .schedule(this.nonceCache, this.nonceCache.getNonceMaxValid(), this.nonceCache.getNonceMaxValid());
+        .schedule(this.nonceCache, this.nonceCache.getNonceMaxValid(), this.nonceCache.getNonceMaxValid());
     }
 
     @Override

--- a/modules/base/api/src/main/java/org/picketlink/authentication/web/FormAuthenticationScheme.java
+++ b/modules/base/api/src/main/java/org/picketlink/authentication/web/FormAuthenticationScheme.java
@@ -18,12 +18,14 @@
 package org.picketlink.authentication.web;
 
 import java.io.IOException;
+
 import javax.servlet.FilterConfig;
 import javax.servlet.RequestDispatcher;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
 import org.picketlink.authentication.web.support.RequestCache;
 import org.picketlink.authentication.web.support.SavedRequest;
 import org.picketlink.credential.DefaultLoginCredentials;
@@ -39,10 +41,10 @@ public class FormAuthenticationScheme implements HTTPAuthenticationScheme{
     public static final String FORM_LOGIN_PAGE_INIT_PARAM = "form-login-page";
     public static final String FORM_ERROR_PAGE_INIT_PARAM = "form-error-page";
 
-    private RequestCache requestCache = new RequestCache();
+    private final RequestCache requestCache = new RequestCache();
 
-    private final String formLoginPage;
-    private final String formErrorPage;
+    private String formLoginPage;
+    private String formErrorPage;
 
     public static final String J_SECURITY_CHECK ="j_security_check";
     public static final String J_USERNAME = "j_username";
@@ -54,7 +56,8 @@ public class FormAuthenticationScheme implements HTTPAuthenticationScheme{
 
     public static final String STATE = "STATE";
 
-    public FormAuthenticationScheme(FilterConfig config) {
+    @Override
+    public void initialize(FilterConfig config) {
         String formLoginPage = config.getInitParameter(FORM_LOGIN_PAGE_INIT_PARAM);
 
         if (formLoginPage == null) {

--- a/modules/base/api/src/main/java/org/picketlink/authentication/web/HTTPAuthenticationScheme.java
+++ b/modules/base/api/src/main/java/org/picketlink/authentication/web/HTTPAuthenticationScheme.java
@@ -24,6 +24,7 @@ package org.picketlink.authentication.web;
 
 import java.io.IOException;
 
+import javax.servlet.FilterConfig;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -31,38 +32,64 @@ import org.picketlink.credential.DefaultLoginCredentials;
 
 
 /**
- * <p>Defines the methods that should be implemented by classes that provide implementations for the HTTP Authentication Schemes
- * such as BASIC, FORM, DIGEST and CLIENT-CERT.</p>
+ * Basis for the HTTP Authentication Schemes such as BASIC, FORM, DIGEST and CLIENT-CERT. Applications can provide their
+ * own authentication schemes by implementing this interface. Implementations must be valid CDI beans, and do support
+ * injection.
  *
  * @author Pedro Silva
- *
+ * @author Jonathan Fuerth
+ * @author Max Barkley
  */
 public interface HTTPAuthenticationScheme {
 
     /**
-     * <p>Extracts the credentials from the given {@link HttpServletRequest} and populate the {@link DefaultLoginCredentials} with them.</p>
+     * Called one time by the {@link AuthenticationFilter} after the CDI initialization has completed, but before any
+     * other methods from this interface are invoked.
+     *
+     * @param config
+     *            the configuration of {@link AuthenticationFilter} from {@code web.xml}. Never null.
+     */
+    void initialize(FilterConfig config);
+
+    /**
+     * Extracts the credentials from the given {@link HttpServletRequest} and populates the
+     * {@link DefaultLoginCredentials} with them. If the request is not an authentication attempt (as defined by the
+     * implementation), then {@code creds} is not affected.
      *
      * @param request
+     *            The current request, to examine for authentication information.
      * @param creds
+     *            The credentials instance that will be populated with the credentials found in the request, if any.
      */
     void extractCredential(HttpServletRequest request, DefaultLoginCredentials creds);
 
     /**
-     * <p>Challenges the client if no credentials were supplied or the credentials were not extracted in order to continue with the authentication.</p>
+     * Challenges the client if no credentials were supplied or the credentials were not extracted in order to continue
+     * with the authentication.
      *
      * @param request
+     *            The current request, which may be used to obtain a {@link javax.servlet.RequestDispatcher} if needed.
+     *            If this method is called, the rest of the filter chain will <i>not</i> be processed, so
+     *            implementations are free to read the request body if they so choose.
      * @param response
+     *            The current response, which can be used to send HTTP error results, redirects, or for sending
+     *            additional challenge headers.
      * @throws IOException
+     *             if reading the request or writing the response fails.
      */
     void challengeClient(HttpServletRequest request, HttpServletResponse response) throws IOException;
 
     /**
-     * <p>Performs any post-authentication logic regarding of the authentication result.</p>
+     * Performs any post-authentication logic regarding of the authentication result.
      *
      * @param request
+     *            The current request, which may be used to obtain a {@link javax.servlet.RequestDispatcher} if needed.
      * @param response
-     * @return true if the processing should continue, false if the processing should stop.
+     *            The current response, which can be used to send an HTTP response, or a redirect.
+     * @return true if the processing of the filter chain should continue, false if the processing should stop
+     *         (typically because this filter has already sent a response).
      * @throws IOException
+     *             if reading the request or writing the response fails.
      */
     boolean postAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException;
 }

--- a/tests/src/test/java/org/picketlink/test/authentication/web/CustomAbstractHttpAuthScheme.java
+++ b/tests/src/test/java/org/picketlink/test/authentication/web/CustomAbstractHttpAuthScheme.java
@@ -1,0 +1,62 @@
+package org.picketlink.test.authentication.web;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+import javax.servlet.FilterConfig;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.picketlink.Identity;
+import org.picketlink.authentication.web.HTTPAuthenticationScheme;
+import org.picketlink.credential.DefaultLoginCredentials;
+
+public abstract class CustomAbstractHttpAuthScheme implements HTTPAuthenticationScheme {
+
+    private boolean hasBeenInitialized;
+    private FilterConfig config;
+
+    @Inject
+    private Identity identity;
+
+
+    @Override
+    public void initialize(FilterConfig config) {
+        this.config = config;
+        hasBeenInitialized = true;
+    }
+
+    @Override
+    public void extractCredential(HttpServletRequest request, DefaultLoginCredentials creds) {
+        // these are the credentials considered valid by this testing setup
+        creds.setUserId("john");
+        creds.setPassword("passwd");
+    }
+
+    @Override
+    public void challengeClient(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        response.setContentType("text/plain");
+        response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+        response.getOutputStream().print("this is a client challenge response");
+        response.flushBuffer();
+    }
+
+    @Override
+    public boolean postAuthentication(HttpServletRequest request, HttpServletResponse response) throws IOException {
+        StringBuilder resp = new StringBuilder();
+        resp.append(getClass().getName());
+        if (hasBeenInitialized) {
+            resp.append(", initialized");
+        }
+        if (config != null) {
+            resp.append(", has_filter_config");
+        }
+        if (identity != null) {
+            resp.append(", has_injected_identity");
+        }
+        response.setContentType("text/plain");
+        response.getOutputStream().print(resp.toString());
+        response.flushBuffer();
+        return false;
+    }
+}

--- a/tests/src/test/java/org/picketlink/test/authentication/web/CustomQualifiedHttpAuthScheme.java
+++ b/tests/src/test/java/org/picketlink/test/authentication/web/CustomQualifiedHttpAuthScheme.java
@@ -1,0 +1,10 @@
+package org.picketlink.test.authentication.web;
+
+import javax.enterprise.context.ApplicationScoped;
+
+import org.picketlink.annotations.PicketLink;
+
+@ApplicationScoped @PicketLink
+public class CustomQualifiedHttpAuthScheme extends CustomAbstractHttpAuthScheme {
+
+}

--- a/tests/src/test/java/org/picketlink/test/authentication/web/CustomUnqualifiedHttpAuthScheme.java
+++ b/tests/src/test/java/org/picketlink/test/authentication/web/CustomUnqualifiedHttpAuthScheme.java
@@ -1,0 +1,8 @@
+package org.picketlink.test.authentication.web;
+
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class CustomUnqualifiedHttpAuthScheme extends CustomAbstractHttpAuthScheme {
+
+}

--- a/tests/src/test/java/org/picketlink/test/authentication/web/CustomWebXmlAuthenticationSchemeTestCase.java
+++ b/tests/src/test/java/org/picketlink/test/authentication/web/CustomWebXmlAuthenticationSchemeTestCase.java
@@ -1,0 +1,93 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2013 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.picketlink.test.authentication.web;
+
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.HttpStatus;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.OperateOnDeployment;
+import org.jboss.shrinkwrap.api.Archive;
+import org.junit.Test;
+
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.WebRequestSettings;
+import com.gargoylesoftware.htmlunit.WebResponse;
+
+/**
+ * @author pedroigor
+ */
+public class CustomWebXmlAuthenticationSchemeTestCase extends AbstractAuthenticationSchemeTestCase {
+
+    @Deployment(name = "configured-in-web-xml", testable = false)
+    public static Archive<?> deployWebXml() {
+        return deploy("configured-in-web-xml.war", "authc-filter-custom-web.xml",
+                CustomAbstractHttpAuthScheme.class,
+                CustomUnqualifiedHttpAuthScheme.class);
+    }
+
+    @Deployment(name = "configured-by-qualified-bean", testable = false)
+    public static Archive<?> deployQualified() {
+        return deploy("configured-by-qualified-bean.war", "authc-filter-not-configured-web.xml",
+                CustomAbstractHttpAuthScheme.class,
+                CustomQualifiedHttpAuthScheme.class);
+    }
+
+    @Deployment(name = "configured-by-both", testable = false)
+    public static Archive<?> deployBoth() {
+        return deploy("configured-by-both.war", "authc-filter-custom-web.xml",
+                CustomAbstractHttpAuthScheme.class,
+                CustomQualifiedHttpAuthScheme.class,
+                CustomUnqualifiedHttpAuthScheme.class);
+    }
+
+    @Test
+    @OperateOnDeployment("configured-in-web-xml")
+    public void testConfigurationByInitParam() throws IOException {
+        WebClient client = new WebClient();
+        WebRequestSettings request = new WebRequestSettings(getProtectedResourceURL());
+        WebResponse response = client.loadWebResponse(request);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(
+                CustomUnqualifiedHttpAuthScheme.class.getName() + ", initialized, has_filter_config, has_injected_identity",
+                response.getContentAsString());
+    }
+
+    @Test
+    @OperateOnDeployment("configured-by-qualified-bean")
+    public void testConfigurationByQualifiedBean() throws IOException {
+        WebClient client = new WebClient();
+        WebRequestSettings request = new WebRequestSettings(getProtectedResourceURL());
+        WebResponse response = client.loadWebResponse(request);
+
+        assertEquals(HttpStatus.SC_OK, response.getStatusCode());
+        assertEquals(
+                CustomQualifiedHttpAuthScheme.class.getName() + ", initialized, has_filter_config, has_injected_identity",
+                response.getContentAsString());
+    }
+
+    @Test
+    @OperateOnDeployment("configured-by-both")
+    public void testQualifiedBeanConfigurationOverridesInitParam() throws IOException {
+        testConfigurationByQualifiedBean();
+    }
+
+}

--- a/tests/src/test/resources/deployments/authc-filter-custom-web.xml
+++ b/tests/src/test/resources/deployments/authc-filter-custom-web.xml
@@ -1,0 +1,47 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+    <filter>
+        <filter-name>PicketLink Authentication Filter</filter-name>
+        <filter-class>org.picketlink.authentication.web.AuthenticationFilter</filter-class>
+
+        <init-param>
+            <param-name>authType</param-name>
+            <param-value>org.picketlink.test.authentication.web.CustomUnqualifiedHttpAuthScheme</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>realmName</param-name>
+            <param-value>Test Realm</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>unprotectedMethods</param-name>
+            <param-value>OPTIONS</param-value>
+        </init-param>
+
+    </filter>
+
+    <filter-mapping>
+        <filter-name>PicketLink Authentication Filter</filter-name>
+        <url-pattern>/protected/*</url-pattern>
+    </filter-mapping>
+
+</web-app>

--- a/tests/src/test/resources/deployments/authc-filter-not-configured-web.xml
+++ b/tests/src/test/resources/deployments/authc-filter-not-configured-web.xml
@@ -1,0 +1,42 @@
+<!--
+    JBoss, Home of Professional Open Source
+    Copyright 2013, Red Hat, Inc. and/or its affiliates, and individual
+    contributors by the @authors tag. See the copyright.txt in the
+    distribution for a full listing of individual contributors.
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+    <filter>
+        <filter-name>PicketLink Authentication Filter</filter-name>
+        <filter-class>org.picketlink.authentication.web.AuthenticationFilter</filter-class>
+
+        <init-param>
+            <param-name>realmName</param-name>
+            <param-value>Test Realm</param-value>
+        </init-param>
+
+        <init-param>
+            <param-name>unprotectedMethods</param-name>
+            <param-value>OPTIONS</param-value>
+        </init-param>
+
+    </filter>
+
+    <filter-mapping>
+        <filter-name>PicketLink Authentication Filter</filter-name>
+        <url-pattern>/protected/*</url-pattern>
+    </filter-mapping>
+
+</web-app>


### PR DESCRIPTION
We had to make a few judgment calls here, definitely interested in your input and happy to change things if you prefer a different approach:
- we made it possible to supply a custom HTTPAuthenticationScheme by annotating an application-provided class (or provider) with @PicketLink. We did this to match similar stuff elsewhere in PicketLink.
- we retained backward compatibility with the existing config mechanism where you name enum constants in the filter config in web.xml
- if you have a @PicketLink auth scheme _and_ an auth scheme specified in web.xml, the @PicketLink bean wins. Other possibilities would have been to let the web.xml config win, or to fail with an error message. Thoughts?
