### PR TITLE
PLINK-464: WSSecurityWriter/WSTrustResponseWriter should use StringUtil ...

### DIFF
--- a/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/writers/WSSecurityWriter.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/writers/WSSecurityWriter.java
@@ -107,7 +107,7 @@ public class WSSecurityWriter {
         StaxUtil.writeNameSpace(writer, WSSE_PREFIX, WSSE_NS);
 
         // write the id attribute, if available.
-        if (secRef.getId() != null && secRef.getId() != "") {
+        if (StringUtil.isNotNull(secRef.getId())) {
             QName wsuIDQName = new QName(WSU_NS, ID, WSU_PREFIX);
             StaxUtil.writeNameSpace(writer, WSU_PREFIX, WSU_NS);
             StaxUtil.writeAttribute(writer, wsuIDQName, secRef.getId());

--- a/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/writers/WSTrustResponseWriter.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/core/wstrust/writers/WSTrustResponseWriter.java
@@ -23,6 +23,7 @@ import org.picketlink.common.PicketLinkLoggerFactory;
 import org.picketlink.common.constants.WSTrustConstants;
 import org.picketlink.common.exceptions.ProcessingException;
 import org.picketlink.common.util.StaxUtil;
+import org.picketlink.common.util.StringUtil;
 import org.picketlink.identity.federation.core.saml.v2.writers.SAMLAssertionWriter;
 import org.picketlink.identity.federation.core.wstrust.wrappers.Lifetime;
 import org.picketlink.identity.federation.core.wstrust.wrappers.RequestSecurityTokenResponse;
@@ -275,8 +276,9 @@ public class WSTrustResponseWriter {
                     WSTrustConstants.BASE_NAMESPACE);
 
             // write the status code.
-            if (status.getCode() == null || status.getCode() == "")
+            if (StringUtil.isNullOrEmpty(status.getCode())) {
                 throw logger.wsTrustValidationStatusCodeMissing();
+            }
             StaxUtil.writeStartElement(this.writer, WSTrustConstants.PREFIX, WSTrustConstants.CODE,
                     WSTrustConstants.BASE_NAMESPACE);
             StaxUtil.writeCharacters(this.writer, response.getStatus().getCode());


### PR DESCRIPTION
...for null string checks
