### PR TITLE
Excluding bad dependencies from WildFly point of view

### DIFF
--- a/modules/idm/tests/pom.xml
+++ b/modules/idm/tests/pom.xml
@@ -139,6 +139,16 @@
       <groupId>org.apache.jmeter</groupId>
       <artifactId>ApacheJMeter_java</artifactId>
       <version>2.9</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>xalan</artifactId>
+          <groupId>xalan</groupId>
+        </exclusion>
+        <exclusion>
+          <artifactId>xalan</artifactId>
+          <groupId>serializer</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <!-- Logging dependencies-->

--- a/pom.xml
+++ b/pom.xml
@@ -143,8 +143,40 @@
 
       <dependency>
         <groupId>org.picketlink</groupId>
+        <artifactId>picketlink-federation</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>apache-xalan</artifactId>
+            <groupId>xalan</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>apache-xalan</artifactId>
+            <groupId>serializer</groupId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+
+      <dependency>
+        <groupId>org.picketlink</groupId>
         <artifactId>picketlink-json</artifactId>
         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>org.picketlink</groupId>
+        <artifactId>picketlink-social</artifactId>
+        <version>${project.version}</version>
+        <exclusions>
+          <exclusion>
+            <artifactId>xalan</artifactId>
+            <groupId>xalan</groupId>
+          </exclusion>
+          <exclusion>
+            <artifactId>xalan</artifactId>
+            <groupId>serializer</groupId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
This PR is excluding dependencies which are scoped as test and are causing problems in WildFly builds.
The deps. are braking their enforcer rules.
