### PR TITLE
Made problems with standard @Inject Principal principal;

### DIFF
--- a/modules/social/src/main/java/org/picketlink/social/standalone/fb/FacebookPrincipal.java
+++ b/modules/social/src/main/java/org/picketlink/social/standalone/fb/FacebookPrincipal.java
@@ -23,12 +23,15 @@ import org.json.JSONObject;
 import java.io.Serializable;
 import java.security.Principal;
 
+import javax.enterprise.inject.Vetoed;
+
 /**
  * An instance of {@link Principal} representing a facebook user
  *
  * @author Marcel Kolsteren
  * @since Sep 26, 2010
  */
+ @Vetoed
 public class FacebookPrincipal implements Principal, Serializable {
     private static final long serialVersionUID = 8086364702249670998L;
 


### PR DESCRIPTION
Without Vetoed it is not possible to use standard

```
@Inject
private Principal principal;
```

The error message is: 

Ambiguous dependencies for type Principal with qualifiers @Default
  Possible dependencies: 
- Built-in Bean [java.security.Principal] with qualifiers [@Default],
- Managed Bean [class org.picketlink.social.standalone.fb.FacebookPrincipal] with qualifiers [@Any @Default]
