### PR TITLE
Made problems with standard @Inject Principal principal, ambiguous dependency

### DIFF
--- a/modules/social/src/main/resources/META-INF/beans.xml
+++ b/modules/social/src/main/resources/META-INF/beans.xml
@@ -20,4 +20,5 @@ limitations under the License.
        xsi:schemaLocation="
 http://java.sun.com/xml/ns/javaee
 http://java.sun.com/xml/ns/javaee/beans_1_0.xsd">
+	<scan><exclude name="org.picketlink.social.standalone.fb.FacebookPrincipal"></exclude></scan>
 </beans>


### PR DESCRIPTION
Without this class being excluded it is not possible to use standard

```
 @Inject
 private Principal principal;
```

The error message is:

```
 Ambiguous dependencies for type Principal with qualifiers @Default
 Possible dependencies:

 Built-in Bean [java.security.Principal] with qualifiers [@Default],
 Managed Bean [class org.picketlink.social.standalone.fb.FacebookPrincipal] with qualifiers [@Any @Default]
```
