### PR TITLE
Parse AuthenticatingAuthority

### DIFF
--- a/modules/federation/src/main/java/org/picketlink/identity/federation/core/parsers/util/SAMLParserUtil.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/core/parsers/util/SAMLParserUtil.java
@@ -46,6 +46,11 @@ import org.picketlink.identity.xmlsec.w3.xmldsig.X509CertificateType;
 import org.picketlink.identity.xmlsec.w3.xmldsig.X509DataType;
 import org.w3c.dom.Element;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.StringTokenizer;
+
 import javax.xml.datatype.XMLGregorianCalendar;
 import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
@@ -53,10 +58,6 @@ import javax.xml.stream.events.Attribute;
 import javax.xml.stream.events.EndElement;
 import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
-import java.net.URI;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.StringTokenizer;
 
 /**
  * Utility methods for SAML Parser
@@ -468,6 +469,10 @@ public class SAMLParserUtil {
                 authnContextSequence.setClassRef(aAuthnContextClassRefType);
 
                 authnContextType.setSequence(authnContextSequence);
+            } else if (JBossSAMLConstants.AUTHENTICATING_AUTHORITY.get().equals(tag)) {
+              startElement = StaxParserUtil.getNextStartElement(xmlEventReader);
+              String text = StaxParserUtil.getElementText(xmlEventReader);
+              authnContextType.addAuthenticatingAuthority(URI.create(text));
             } else
                 throw logger.parserUnknownTag(tag, startElement.getLocation());
         }


### PR DESCRIPTION
Fix https://issues.jboss.org/browse/PLINK2-125.

Accept AUTHENTICATING_AUTHORITY when parsing  AuthnContextType in SAMLParserUtil.
