### PR TITLE
PLINK-659 Add Handling of NameIDType in SAML2AuthenticationHandler.getRo...

### DIFF
--- a/modules/federation/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/web/handlers/saml2/SAML2AuthenticationHandler.java
@@ -701,6 +701,9 @@ public class SAML2AuthenticationHandler extends BaseSAML2Handler {
                         } else if (attrValue instanceof Node) {
                             Node roleNode = (Node) attrValue;
                             roles.add(roleNode.getFirstChild().getNodeValue());
+                        } else if (attrValue instanceof NameIDType) {
+                          NameIDType nameIdType = (NameIDType) attrValue;
+                          roles.add(nameIdType.getValue());
                         } else
                             throw logger.unsupportedRoleType(attrValue);
                     }


### PR DESCRIPTION
This adds handling of the NameIDType to SAML2AuthenticationHandler.getRoles and allows for successful testing against the testship.org IDP.