### PR TITLE
[PLINK-667] Added test cases for CORS Authorization to HTTP Security API

### DIFF
--- a/modules/base/api/src/main/java/org/picketlink/config/http/CORSConfiguration.java
+++ b/modules/base/api/src/main/java/org/picketlink/config/http/CORSConfiguration.java
@@ -28,7 +28,6 @@ import java.util.Set;
  */
 public class CORSConfiguration {
 
-    private final boolean allowGenericHttpRequests;
     private final Set<String> allowedOrigins;
     private final Set<String> supportedMethods;
     private final Set<String> supportedHeaders;
@@ -39,12 +38,11 @@ public class CORSConfiguration {
     private final long maxAge;
     private final PathConfiguration pathConfiguration;
 
-    public CORSConfiguration(PathConfiguration pathConfiguration, boolean allowGenericHttpRequests, Set<String> allowedOrigins,
+    public CORSConfiguration(PathConfiguration pathConfiguration, Set<String> allowedOrigins,
             Set<String> supportedMethods, Set<String> supportedHeaders, Set<String> exposedHeaders,
             boolean supportsCredentials, boolean allowAnyOrigin, boolean supportAnyHeader, long maxAge) {
 
         this.pathConfiguration = pathConfiguration;
-        this.allowGenericHttpRequests = allowGenericHttpRequests;
         this.allowedOrigins = allowedOrigins;
         this.supportedMethods = supportedMethods;
         this.supportedHeaders = supportedHeaders;
@@ -53,10 +51,6 @@ public class CORSConfiguration {
         this.allowAnyOrigin = allowAnyOrigin;
         this.supportAnyHeader = supportAnyHeader;
         this.maxAge = maxAge;
-    }
-
-    public boolean isGenericHttpRequestsAllowed() {
-        return this.allowGenericHttpRequests;
     }
 
     public Set<String> getAllowedOrigins() {

--- a/modules/base/api/src/main/java/org/picketlink/config/http/CORSConfigurationBuilder.java
+++ b/modules/base/api/src/main/java/org/picketlink/config/http/CORSConfigurationBuilder.java
@@ -30,7 +30,6 @@ import java.util.Set;
  */
 public class CORSConfigurationBuilder extends AbstractPathConfigurationChildBuilder {
 
-    private boolean allowGenericHttpRequests;
     private Set<String> allowedOrigins;
     private Set<String> supportedMethods;
     private Set<String> supportedHeaders;
@@ -42,11 +41,6 @@ public class CORSConfigurationBuilder extends AbstractPathConfigurationChildBuil
 
     CORSConfigurationBuilder(PathConfigurationBuilder parentBuilder) {
         super(parentBuilder);
-    }
-
-    public CORSConfigurationBuilder allowedGenericHttpRequests(boolean isGenericHttpRequestsAllowed) {
-        this.allowGenericHttpRequests = isGenericHttpRequestsAllowed;
-        return this;
     }
 
     public CORSConfigurationBuilder allowedOrigins(String... allowedOrigins) {
@@ -90,7 +84,7 @@ public class CORSConfigurationBuilder extends AbstractPathConfigurationChildBuil
     }
 
     CORSConfiguration create(PathConfiguration pathConfiguration) {
-        return new CORSConfiguration(pathConfiguration, allowGenericHttpRequests, allowedOrigins, supportedMethods,
+        return new CORSConfiguration(pathConfiguration, allowedOrigins, supportedMethods,
                 supportedHeaders, exposedHeaders, supportsCredentials, allowAnyOrigin, supportAnyHeader, maxAge);
     }
 }

--- a/modules/base/api/src/main/java/org/picketlink/config/http/PathConfiguration.java
+++ b/modules/base/api/src/main/java/org/picketlink/config/http/PathConfiguration.java
@@ -212,7 +212,6 @@ public class PathConfiguration {
             CORSConfiguration groupCORSAuthz = groupConfiguration.getCORSConfiguration();
 
             if (this.corsConfiguration != null && groupCORSAuthz != null) {
-                boolean allowGenericHttpRequests = this.corsConfiguration.isGenericHttpRequestsAllowed();
                 Set<String> allowedOrigins = this.corsConfiguration.getAllowedOrigins();
                 Set<String> supportedMethods = this.corsConfiguration.getSupportedMethods();
                 Set<String> supportedHeaders = this.corsConfiguration.getSupportedHeaders();
@@ -221,10 +220,6 @@ public class PathConfiguration {
                 boolean allowAnyOrigin = this.corsConfiguration.isAnyOriginAllowed();
                 boolean supportAnyHeader = this.corsConfiguration.isAnyHeaderSupported();
                 long maxAge = this.corsConfiguration.getMaxAge();
-
-                if (Boolean.valueOf(allowGenericHttpRequests) == null) {
-                    allowGenericHttpRequests = groupCORSAuthz.isGenericHttpRequestsAllowed();
-                }
 
                 if (allowedOrigins == null) {
                     allowedOrigins = groupCORSAuthz.getAllowedOrigins();
@@ -250,7 +245,7 @@ public class PathConfiguration {
                     maxAge = groupCORSAuthz.getMaxAge();
                 }
 
-                return new CORSConfiguration(this, allowGenericHttpRequests, allowedOrigins, supportedMethods,
+                return new CORSConfiguration(this, allowedOrigins, supportedMethods,
                         supportedHeaders, exposedHeaders, supportsCredentials, allowAnyOrigin, supportAnyHeader, maxAge);
             } else if (groupCORSAuthz != null) {
                 return groupConfiguration.getCORSConfiguration();

--- a/modules/base/impl/src/main/java/org/picketlink/http/internal/SecurityFilter.java
+++ b/modules/base/impl/src/main/java/org/picketlink/http/internal/SecurityFilter.java
@@ -391,11 +391,8 @@ public class SecurityFilter implements Filter {
                 } else if (type.equals(CORSRequestType.PREFLIGHT)) {
                     // Preflight CORS request
                     cors.handlePreflightRequest(corsConfiguration, request, response);
-                } else if (corsConfiguration.isGenericHttpRequestsAllowed()) {
-                    // Not a CORS request, allow it through
                 } else {
-                    // Generic HTTP requests denied
-                    throw new RuntimeException("Generic HTTP requests not allowed");
+                    // Not a CORS request, allow it through
                 }
             }
         }

--- a/modules/base/impl/src/test/java/org/picketlink/http/test/cors/CORSAuthorizationTestCase.java
+++ b/modules/base/impl/src/test/java/org/picketlink/http/test/cors/CORSAuthorizationTestCase.java
@@ -21,6 +21,16 @@
  */
 package org.picketlink.http.test.cors;
 
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import javax.enterprise.event.Observes;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.junit.Test;
 import org.picketlink.config.SecurityConfigurationBuilder;
 import org.picketlink.event.SecurityConfigurationEvent;
@@ -28,12 +38,6 @@ import org.picketlink.http.internal.cors.CORS;
 import org.picketlink.http.test.AbstractSecurityFilterTestCase;
 import org.picketlink.http.test.SecurityInitializer;
 import org.picketlink.test.weld.Deployment;
-
-import javax.enterprise.event.Observes;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests the CORS requests via SecurityFilter.
@@ -44,32 +48,194 @@ import static org.mockito.Mockito.when;
 public class CORSAuthorizationTestCase extends AbstractSecurityFilterTestCase {
 
     @Test
-    public void testActualRequestWithDefaultConfiguration() throws Exception {
+    public void testSimpleActualRequests() throws Exception {
+        // Actual Request with one of allowed origin
         when(this.request.getServletPath()).thenReturn("/corsAuthorization");
 
-        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("https://www.example.org:9000");
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.org:9000");
         when(this.request.getMethod()).thenReturn("PUT");
 
         this.securityFilter.doFilter(this.request, this.response, this.filterChain);
 
+        verify(this.filterChain, times(1)).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
         verify(this.response, times(1)).addHeader("Access-Control-Allow-Credentials", "true");
-        verify(this.response, times(1)).addHeader("Access-Control-Allow-Origin", "https://www.example.org:9000");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Origin", "http://www.example.org:9000");
+        verify(this.response, times(1)).addHeader("Access-Control-Expose-Headers", "Origin, Accept");
+        verify(this.response, times(0)).addHeader("Access-Control-Max-Age", "3600");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS, PUT");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Headers",
+                "Authorization, X-Requested-With, Origin, Accept, Content-Type");
+        
+        // Actual Request with another allowed origin
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.com:8008");
+        when(this.request.getMethod()).thenReturn("GET");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+
+        verify(this.filterChain, times(2)).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Credentials", "true");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Origin", "http://www.example.com:8008");
+        verify(this.response, times(1)).addHeader("Access-Control-Expose-Headers", "Origin, Accept");
+        verify(this.response, times(0)).addHeader("Access-Control-Max-Age", "3600");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS, PUT");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Headers",
+                "Authorization, X-Requested-With, Origin, Accept, Content-Type");
 
     }
 
+    @Test
+    public void testSimplePreflightRequests() throws Exception {
+        
+        // Preflight Request with one of allowed origin
+        when(this.request.getServletPath()).thenReturn("/corsAuthorization");
+
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.org:9000");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("GET");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Content-Type, Accept");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+
+        verify(this.filterChain, times(1)).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Credentials", "true");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Origin", "http://www.example.org:9000");
+        verify(this.response, times(0)).addHeader("Access-Control-Expose-Headers", "Origin, Accept");
+        verify(this.response, times(1)).addHeader("Access-Control-Max-Age", "3600");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS, PUT");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Headers",
+                "Authorization, X-Requested-With, Origin, Accept, Content-Type");
+        
+        // Preflight Request with another allowed origin
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.com:8008");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("POST");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Authorization, Origin");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+
+        verify(this.filterChain, times(2)).doFilter(any(HttpServletRequest.class), any(HttpServletResponse.class));
+
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Credentials", "true");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Origin", "http://www.example.com:8008");
+        verify(this.response, times(0)).addHeader("Access-Control-Expose-Headers", "Origin, Accept");
+        verify(this.response, times(1)).addHeader("Access-Control-Max-Age", "3600");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS, PUT");
+        verify(this.response, times(1)).addHeader("Access-Control-Allow-Headers",
+                "Authorization, X-Requested-With, Origin, Accept, Content-Type");
+
+    }
+
+    @Test
+    public void testOtherRequest() throws Exception {
+        
+        // Other request (CORS headers are not added)
+        when(this.request.getServletPath()).thenReturn("/corsAuthorization");
+        
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn(null);
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Credentials", "true");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Origin", "http://www.example.com:8008");
+        verify(this.response, times(0)).addHeader("Access-Control-Expose-Headers", "Origin, Accept");
+        verify(this.response, times(0)).addHeader("Access-Control-Max-Age", "3600");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Methods", "POST, GET, DELETE, OPTIONS, PUT");
+        verify(this.response, times(0)).addHeader("Access-Control-Allow-Headers",
+                "Authorization, X-Requested-With, Origin, Accept, Content-Type");
+
+    }
+    
+    @Test
+    public void testInvalidActualRequests() throws Exception {
+        
+        // Actual request CORS origin denied
+        when(this.request.getServletPath()).thenReturn("/corsAuthorization");
+
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.com:9000");
+        when(this.request.getMethod()).thenReturn("PUT");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "CORS origin denied http://www.example.com:9000");
+        
+        // Actual request Unsupported HTTP method
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.com:8008");
+        when(this.request.getMethod()).thenReturn("HEAD");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "Unsupported HTTP method HEAD");
+
+    }
+    
+    @Test
+    public void testInvalidPreflightRequests() throws Exception {
+        
+        // Preflight request CORS origin denied
+        when(this.request.getServletPath()).thenReturn("/corsAuthorization");
+
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.com:9000");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("GET");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Content-Type, Accept");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "CORS origin denied http://www.example.com:9000");
+        
+        // Preflight request Unsupported HTTP method HEAD
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.org:9000");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("HEAD");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Content-Type, Accept");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "Unsupported HTTP access control request method HEAD");
+        
+        // Preflight request Unsupported HTTP header Invalid-Header-Value
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.org:9000");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("POST");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Content-Type, Invalid-Header-Value");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "Unsupported HTTP access control request header Invalid-Header-Value");
+        
+        // Preflight request Unsupported HTTP header format(s)
+        reset(this.response);
+        when(this.request.getHeader(CORS.ORIGIN)).thenReturn("http://www.example.org:9000");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_METHOD)).thenReturn("POST");
+        when(this.request.getHeader(CORS.ACCESS_CONTROL_REQUEST_HEADERS)).thenReturn("Content-Type, X-r@b");
+        when(this.request.getMethod()).thenReturn("OPTIONS");
+
+        this.securityFilter.doFilter(this.request, this.response, this.filterChain);
+        
+        verify(this.response, times(1)).sendError(500, "Invalid preflight CORS request: Bad request header value X-r@b");
+
+
+    }
+    
     public static class SecurityConfiguration {
         public void configureHttpSecurity(@Observes SecurityConfigurationEvent event) throws Exception {
 
             SecurityConfigurationBuilder builder = event.getBuilder();
             builder.http().forPath("/corsAuthorization")
-             .cors()
-             .allowedGenericHttpRequests(true)
-             .allowedOrigins("https://www.example.org:9000", "http://example.com:8008")
-             .supportedMethods("GET", "PUT", "HEAD", "POST", "DELETE", "OPTIONS")
-             .supportedHeaders("Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization")
-             .exposedHeaders()
-             .supportsCredentials(true)
-             .maxAge(3600);
+            .cors()
+            .allowedOrigins("http://www.example.org:9000", "http://www.example.com:8008")
+            .supportedMethods("GET", "PUT", "POST", "DELETE", "OPTIONS")
+            .supportedHeaders("Origin", "X-Requested-With", "Content-Type", "Accept", "Authorization")
+            .exposedHeaders("Origin", "Accept")
+            .supportsCredentials(true).maxAge(3600);
         }
     }
 

--- a/modules/base/impl/src/test/java/org/picketlink/http/test/cors/CorsUtilTest.java
+++ b/modules/base/impl/src/test/java/org/picketlink/http/test/cors/CorsUtilTest.java
@@ -21,10 +21,18 @@
  */
 package org.picketlink.http.test.cors;
 
+import java.util.HashSet;
+import java.util.Set;
+
 import junit.framework.TestCase;
 
 import org.picketlink.http.internal.cors.CorsUtil;
 
+/**
+ * Tests the CORS Utility methods.
+ *
+ * @author Giriraj Sharma
+ */
 public class CorsUtilTest extends TestCase {
 
     public void testParseMultipleHeaderValues() {
@@ -54,12 +62,28 @@ public class CorsUtilTest extends TestCase {
         assertEquals("HEAD", out[2]);
         assertEquals(3, out.length);
 
+        out = CorsUtil.parseMultipleHeaderValues("GET ,    PUT,       HEAD");
+
+        assertEquals("GET", out[0]);
+        assertEquals("PUT", out[1]);
+        assertEquals("HEAD", out[2]);
+        assertEquals(3, out.length);
+
         out = CorsUtil.parseMultipleHeaderValues("GET PUT HEAD");
 
         assertEquals("GET", out[0]);
         assertEquals("PUT", out[1]);
         assertEquals("HEAD", out[2]);
         assertEquals(3, out.length);
+    }
+
+    public void testTrim() {
+        String expected = "Content-Type";
+        String n1 = CorsUtil.formatCanonical("content-type\n");
+        String n2 = CorsUtil.formatCanonical(" CONTEnt-Type ");
+
+        assertEquals("All whitespace should be trimmed", expected, n1);
+        assertEquals("All whitespace should be trimmed", expected, n2);
     }
 
     public void testFormatCanonical() {
@@ -73,9 +97,94 @@ public class CorsUtilTest extends TestCase {
         try {
             assertEquals(CorsUtil.formatCanonical(""), "");
             fail("Failed to raise IllegalArgumentException on empty string");
-
         } catch (IllegalArgumentException e) {
             // ok
         }
     }
+
+    public void testInvalid1() {
+        assertInvalid("X-r@b");
+    }
+
+    public void testInvalid2() {
+        assertInvalid("1=X-r");
+    }
+
+    public void testInvalid3() {
+        assertInvalid("Aaa Bbb");
+    }
+
+    public void testInvalid4() {
+        assertInvalid("less<than");
+    }
+
+    public void testInvalid5() {
+        assertInvalid("alpha1>");
+    }
+
+    public void testInvalid6() {
+        assertInvalid("X-Forwarded-By-{");
+    }
+
+    public void testInvalid7() {
+        assertInvalid("a}");
+    }
+
+    public void testInvalid8() {
+        assertInvalid("separator:");
+    }
+
+    public void testInvalid9() {
+        assertInvalid("asd\"f;");
+    }
+
+    public void testInvalid10() {
+        assertInvalid("rfc@w3c.org");
+    }
+
+    public void testInvalid11() {
+        assertInvalid("bracket[");
+    }
+
+    public void testInvalid12() {
+        assertInvalid("control\u0002header");
+    }
+
+    public void testInvalid13() {
+        assertInvalid("control\nembedded");
+    }
+
+    public void testInvalid14() {
+        assertInvalid("uni╚(•⌂•)╝");
+    }
+
+    public void testInvalid15() {
+        assertInvalid("uni\u3232_\u3232");
+    }
+
+    public void testUnusualButValid() {
+        CorsUtil.formatCanonical("__2");
+        CorsUtil.formatCanonical("$%.%");
+        CorsUtil.formatCanonical("`~'&#*!^|");
+        CorsUtil.formatCanonical("Original_Name");
+    }
+
+    private void assertInvalid(String header) {
+        try {
+            CorsUtil.formatCanonical(header);
+            fail("Failed to raise exeption on bad header name");
+        } catch (IllegalArgumentException e) {
+            // ok
+        }
+    }
+
+    public void testJoin() {
+        Set<String> supportedMethods = new HashSet<String>();
+        supportedMethods.add("HEAD");
+        supportedMethods.add("PUT");
+        supportedMethods.add("DELETE");
+
+        assertEquals(CorsUtil.join(supportedMethods), "DELETE, PUT, HEAD");
+    }
+
 }


### PR DESCRIPTION
Changes in this PR are limited to PL HTTP Security API and is meant to provide test cases to CORS Authorization. 
It is however, surprising why it is resulting in test case failures in federation module [https://picketlink.ci.cloudbees.com/job/picketlink/333/].