### PR TITLE
Update jboss-logging dependencies and migrate annotations to the non-deprecated annotations

### DIFF
--- a/modules/base/api/src/main/java/org/picketlink/log/BaseLog.java
+++ b/modules/base/api/src/main/java/org/picketlink/log/BaseLog.java
@@ -21,11 +21,11 @@
  */
 package org.picketlink.log;
 
-import org.jboss.logging.Cause;
-import org.jboss.logging.LogMessage;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 import org.picketlink.Identity;
 import org.picketlink.common.logging.Log;
 import org.picketlink.common.logging.LogFactory;

--- a/modules/base/pom.xml
+++ b/modules/base/pom.xml
@@ -17,7 +17,19 @@
   <dependencies>
     <dependency>
       <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/modules/federation/pom.xml
+++ b/modules/federation/pom.xml
@@ -120,11 +120,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
       <scope>test</scope>

--- a/modules/idm/api/src/main/java/org/picketlink/idm/IDMLog.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/IDMLog.java
@@ -22,10 +22,10 @@
 
 package org.picketlink.idm;
 
-import org.jboss.logging.LogMessage;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger.Level;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 import org.picketlink.common.logging.Log;
 import org.picketlink.common.logging.LogFactory;
 import org.picketlink.idm.model.Account;

--- a/modules/idm/api/src/main/java/org/picketlink/idm/IDMMessages.java
+++ b/modules/idm/api/src/main/java/org/picketlink/idm/IDMMessages.java
@@ -22,9 +22,9 @@
 
 package org.picketlink.idm;
 
-import org.jboss.logging.Cause;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageBundle;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
 import org.jboss.logging.Messages;
 import org.picketlink.common.exceptions.NotImplementedException;
 import org.picketlink.idm.config.IdentityStoreConfiguration;

--- a/modules/idm/impl/src/main/java/org/picketlink/idm/IDMInternalLog.java
+++ b/modules/idm/impl/src/main/java/org/picketlink/idm/IDMInternalLog.java
@@ -1,9 +1,9 @@
 package org.picketlink.idm;
 
-import org.jboss.logging.LogMessage;
+import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.Logger;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageLogger;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageLogger;
 import org.picketlink.common.logging.LogFactory;
 import org.picketlink.idm.model.AttributedType;
 

--- a/modules/idm/impl/src/main/java/org/picketlink/idm/IDMInternalMessages.java
+++ b/modules/idm/impl/src/main/java/org/picketlink/idm/IDMInternalMessages.java
@@ -22,11 +22,11 @@
 
 package org.picketlink.idm;
 
-import org.jboss.logging.Cause;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageBundle;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
 import org.jboss.logging.Messages;
-import org.jboss.logging.Param;
+import org.jboss.logging.annotations.Param;
 import org.picketlink.idm.config.IdentityStoreConfiguration;
 import org.picketlink.idm.config.OperationNotSupportedException;
 import org.picketlink.idm.model.AttributedType;

--- a/modules/idm/pom.xml
+++ b/modules/idm/pom.xml
@@ -17,7 +17,20 @@
   <dependencies>
     <dependency>
       <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -71,7 +71,19 @@
     </dependency>
     <dependency>
       <groupId>org.jboss.logging</groupId>
+      <artifactId>jboss-logging-annotations</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.logging</groupId>
       <artifactId>jboss-logging-processor</artifactId>
+      <!-- This is a compile-time dependency of this project, but is not needed at compile or runtime by other
+            projects that depend on this project.-->
+      <optional>true</optional>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.glassfish</groupId>

--- a/modules/json/src/main/java/org/picketlink/json/JsonMessages.java
+++ b/modules/json/src/main/java/org/picketlink/json/JsonMessages.java
@@ -17,9 +17,9 @@
  */
 package org.picketlink.json;
 
-import org.jboss.logging.Cause;
-import org.jboss.logging.Message;
-import org.jboss.logging.MessageBundle;
+import org.jboss.logging.annotations.Cause;
+import org.jboss.logging.annotations.Message;
+import org.jboss.logging.annotations.MessageBundle;
 import org.jboss.logging.Messages;
 import org.picketlink.json.jose.crypto.Algorithm;
 

--- a/modules/oauth/pom.xml
+++ b/modules/oauth/pom.xml
@@ -209,11 +209,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-    </dependency>
-
-    <dependency>
       <groupId>org.picketbox</groupId>
       <artifactId>picketbox-ldap</artifactId>
       <version>1.0.2.Final</version>

--- a/modules/rest/bin/pom.xml
+++ b/modules/rest/bin/pom.xml
@@ -287,12 +287,6 @@
          <scope>test</scope>
       </dependency>
       <dependency>
-         <groupId>org.jboss.logging</groupId>
-         <artifactId>jboss-logging-processor</artifactId>
-         <scope>provided</scope>
-         <optional>true</optional>
-      </dependency>
-      <dependency>
          <groupId>org.jboss.weld.servlet</groupId>
          <artifactId>weld-servlet</artifactId>
          <scope>test</scope>

--- a/modules/rest/pom.xml
+++ b/modules/rest/pom.xml
@@ -256,13 +256,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.jboss.logging</groupId>
-      <artifactId>jboss-logging-processor</artifactId>
-      <scope>provided</scope>
-      <optional>true</optional>
-    </dependency>
-
-    <dependency>
       <groupId>org.jboss.weld.servlet</groupId>
       <artifactId>weld-servlet</artifactId>
       <scope>test</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -63,8 +63,8 @@
     <version.javax.el>2.2.4</version.javax.el>
     <shrinkwrap.resolver.version>2.0.0-beta-2</shrinkwrap.resolver.version>
     <arquillian.version>1.0.3.Final</arquillian.version>
-    <jboss.logging.version>3.1.1.GA</jboss.logging.version>
-    <jboss.logging.processor.version>1.0.3.Final</jboss.logging.processor.version>
+    <jboss.logging.version>3.2.1.Final</jboss.logging.version>
+    <jboss.logging.processor.version>1.2.1.Final</jboss.logging.processor.version>
     <junit.version>4.10</junit.version>
     <mockito.version>1.9.0</mockito.version>
   </properties>
@@ -231,6 +231,13 @@
         <groupId>org.jboss.logging</groupId>
         <artifactId>jboss-logging</artifactId>
         <version>${jboss.logging.version}</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <dependency>
+        <groupId>org.jboss.logging</groupId>
+        <artifactId>jboss-logging-annotations</artifactId>
+        <version>${jboss.logging.processor.version}</version>
         <scope>provided</scope>
       </dependency>
 


### PR DESCRIPTION
Picklink is using an old version of the log processor that generates the message id and message strings inefficiently at runtime. This PR upgrades the logging libraries and changes the message loggers and bundles to use the new annotation namespace.

It also removes the logging processor from pom's that don't need it.