### PR TITLE
Update SerializablePrincipal.java

### DIFF
--- a/modules/federation/src/main/java/org/picketlink/identity/federation/core/SerializablePrincipal.java
+++ b/modules/federation/src/main/java/org/picketlink/identity/federation/core/SerializablePrincipal.java
@@ -39,4 +39,34 @@ public class SerializablePrincipal implements Principal, Serializable {
     public String getName() {
         return name;
     }
+    
+    /**
+     * Compare this SerializablePrincipal's name against another Principal.
+     * @return true if name equals another.getName();
+     */ 
+    @Override
+    public boolean equals(Object another)
+    {
+       if (!(another instanceof Principal))
+          return false;
+       String anotherName = ((Principal) another).getName();
+       boolean equals = false;
+       if (name == null)
+          equals = anotherName == null;
+       else
+          equals = name.equals(anotherName);
+       return equals;
+    }
+
+    @Override
+    public int hashCode()
+    {
+       return (name == null ? 0 : name.hashCode());
+    }
+
+    @Override
+    public String toString()
+    {
+       return name;
+    }
 }


### PR DESCRIPTION
https://github.com/picketbox/picketbox/blob/eaed8ecb93e6ce002eb50d2f515df032e2013839/picketbox-infinispan/src/main/java/org/jboss/security/authentication/JBossCachedAuthenticationManager.java#L74

JBossCachedAuthenticationManager.domainCache() will use Principal as map key,
so the implement class of Principal should implement method equals() and hashCode();