### PR TITLE
Catch child classes of IdentityType

### DIFF
--- a/modules/idm/impl/src/main/java/org/picketlink/idm/internal/util/RelationshipMetadata.java
+++ b/modules/idm/impl/src/main/java/org/picketlink/idm/internal/util/RelationshipMetadata.java
@@ -72,7 +72,7 @@ public class RelationshipMetadata {
 
     private Set<Property<? extends IdentityType>> queryRelationshipIdentityProperties(Class<? extends Relationship> relationshipClass) {
         PropertyQuery<? extends IdentityType> query = PropertyQueries.createQuery(relationshipClass);
-        query.addCriteria(new TypedPropertyCriteria(IdentityType.class));
+        query.addCriteria(new TypedPropertyCriteria(IdentityType.class, MatchOption.SUB_TYPE));
 
         Set<Property<? extends IdentityType>> properties = new HashSet<Property<? extends IdentityType>>();
         for (Property<? extends IdentityType> prop : query.getResultList()) {


### PR DESCRIPTION
When persisting any relationship to the relationship manager, I was getting this error:

> org.picketlink.idm.config.OperationNotSupportedException: PLIDM000604: No identity store configuration found for requested type operation [class path.to.MyRelationshipEntity.create].

I found that while the relationship object's user and group properties were being queried for their partition, no matching users or groups were found because the search criteria was not allowing child classes of `IdentityType`. This solves the problem.

A workaround is to add `configurationBuilder.supportGlobalRelationship(org.picketlink.idm.model.Relationship.class);` or `configurationBuilder.supportAllFeatures();` to your configuration.