### PR TITLE
2.6.x

### DIFF
--- a/bom/picketlink-javaee-6.0-with-deltaspike/pom.xml
+++ b/bom/picketlink-javaee-6.0-with-deltaspike/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-javaee-6.0</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../picketlink-javaee-6.0/pom.xml</relativePath>
   </parent>
 

--- a/bom/picketlink-javaee-6.0-with-deltaspike/pom.xml
+++ b/bom/picketlink-javaee-6.0-with-deltaspike/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-javaee-6.0</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../picketlink-javaee-6.0/pom.xml</relativePath>
   </parent>
 

--- a/bom/picketlink-javaee-6.0/pom.xml
+++ b/bom/picketlink-javaee-6.0/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-bom-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/picketlink-javaee-6.0/pom.xml
+++ b/bom/picketlink-javaee-6.0/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-bom-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-bom-parent</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PicketLink BOM Parent</name>

--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-bom-parent</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PicketLink BOM Parent</name>

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/build-config/pom.xml
+++ b/build-config/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dist/full/pom.xml
+++ b/dist/full/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-dist-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dist/full/pom.xml
+++ b/dist/full/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-dist-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/dist/pom.xml
+++ b/dist/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/docs/pom.xml
+++ b/docs/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/examples/security-console/pom.xml
+++ b/examples/security-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-parent</artifactId>
-        <version>2.6.0-SNAPSHOT</version>
+        <version>2.6.1-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/examples/security-console/pom.xml
+++ b/examples/security-console/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.picketlink</groupId>
         <artifactId>picketlink-parent</artifactId>
-        <version>2.6.1-SNAPSHOT</version>
+        <version>2.6.2-SNAPSHOT</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/forge/addon/pom.xml
+++ b/forge/addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge</artifactId>
   <dependencies>

--- a/forge/addon/pom.xml
+++ b/forge/addon/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge</artifactId>
   <dependencies>

--- a/forge/api/pom.xml
+++ b/forge/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-api</artifactId>
   <dependencies>

--- a/forge/api/pom.xml
+++ b/forge/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-api</artifactId>
   <dependencies>

--- a/forge/impl/pom.xml
+++ b/forge/impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-impl</artifactId>
   <dependencies>

--- a/forge/impl/pom.xml
+++ b/forge/impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-impl</artifactId>
   <dependencies>

--- a/forge/pom.xml
+++ b/forge/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.picketlink.forge</groupId>
   <artifactId>picketlink-forge-parent</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>addon</module>

--- a/forge/pom.xml
+++ b/forge/pom.xml
@@ -4,7 +4,7 @@
   <modelVersion>4.0.0</modelVersion>
   <groupId>org.picketlink.forge</groupId>
   <artifactId>picketlink-forge-parent</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.2-SNAPSHOT</version>
   <packaging>pom</packaging>
   <modules>
     <module>addon</module>

--- a/forge/spi/pom.xml
+++ b/forge/spi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-spi</artifactId>
   <dependencies>

--- a/forge/spi/pom.xml
+++ b/forge/spi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-spi</artifactId>
   <dependencies>

--- a/forge/tests/pom.xml
+++ b/forge/tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-tests</artifactId>
   <dependencies>

--- a/forge/tests/pom.xml
+++ b/forge/tests/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink.forge</groupId>
     <artifactId>picketlink-forge-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
   </parent>
   <artifactId>picketlink-forge-tests</artifactId>
   <dependencies>

--- a/maven-plugins/picketlink-jdocbook-style/pom.xml
+++ b/maven-plugins/picketlink-jdocbook-style/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-jdocbook-style</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.2-SNAPSHOT</version>
   <packaging>jdocbook-style</packaging>
 
   <name>PicketLink Documentation Style</name>

--- a/maven-plugins/picketlink-jdocbook-style/pom.xml
+++ b/maven-plugins/picketlink-jdocbook-style/pom.xml
@@ -10,7 +10,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-jdocbook-style</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.6.1-SNAPSHOT</version>
   <packaging>jdocbook-style</packaging>
 
   <name>PicketLink Documentation Style</name>

--- a/modules/base/api/pom.xml
+++ b/modules/base/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-base-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/base/api/pom.xml
+++ b/modules/base/api/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-base-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/base/impl/pom.xml
+++ b/modules/base/impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-base-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/base/impl/pom.xml
+++ b/modules/base/impl/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-base-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/base/pom.xml
+++ b/modules/base/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/base/pom.xml
+++ b/modules/base/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/common/pom.xml
+++ b/modules/common/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/common/src/main/java/org/picketlink/common/DefaultPicketLinkLogger.java
+++ b/modules/common/src/main/java/org/picketlink/common/DefaultPicketLinkLogger.java
@@ -2374,4 +2374,9 @@ public class DefaultPicketLinkLogger implements PicketLinkLogger {
         return new RuntimeException("Cannot set maximum STS client pool size to negative number (" + max + ")");
     }
 
+    @Override
+    public RuntimeException parserFeatureNotSupported(String feature) {
+        return new RuntimeException("Parser feature " + feature + " not supported.");
+    }
+
 }

--- a/modules/common/src/main/java/org/picketlink/common/PicketLinkLogger.java
+++ b/modules/common/src/main/java/org/picketlink/common/PicketLinkLogger.java
@@ -1215,4 +1215,6 @@ public interface PicketLinkLogger {
 
     RuntimeException cannotSetMaxPoolSizeToNegative(String max);
 
+    RuntimeException parserFeatureNotSupported(String feature);
+
 }

--- a/modules/common/src/main/java/org/picketlink/common/util/DocumentUtil.java
+++ b/modules/common/src/main/java/org/picketlink/common/util/DocumentUtil.java
@@ -66,6 +66,10 @@ public class DocumentUtil {
 
     private static DocumentBuilderFactory documentBuilderFactory;
 
+    public static final String feature_external_general_entities = "http://xml.org/sax/features/external-general-entities";
+    public static final String feature_external_parameter_entities = "http://xml.org/sax/features/external-parameter-entities";
+    public static final String feature_disallow_doctype_decl = "http://apache.org/xml/features/disallow-doctype-decl";
+
     /**
      * Check whether a node belongs to a document
      *
@@ -517,6 +521,17 @@ public class DocumentUtil {
                 documentBuilderFactory = DocumentBuilderFactory.newInstance();
                 documentBuilderFactory.setNamespaceAware(true);
                 documentBuilderFactory.setXIncludeAware(true);
+                String feature = "";
+                try {
+                    feature = feature_disallow_doctype_decl;
+                    documentBuilderFactory.setFeature(feature, true);
+                    feature = feature_external_general_entities;
+                    documentBuilderFactory.setFeature(feature, false);
+                    feature = feature_external_parameter_entities;
+                    documentBuilderFactory.setFeature(feature, false);
+                } catch (ParserConfigurationException e) {
+                    throw logger.parserFeatureNotSupported(feature);
+                }
             } finally {
                 if (tccl_jaxp) {
                     SecurityActions.setTCCL(prevTCCL);

--- a/modules/config/pom.xml
+++ b/modules/config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/config/pom.xml
+++ b/modules/config/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/deltaspike/pom.xml
+++ b/modules/deltaspike/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/deltaspike/pom.xml
+++ b/modules/deltaspike/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/federation/pom.xml
+++ b/modules/federation/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/federation/pom.xml
+++ b/modules/federation/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/idm/api/pom.xml
+++ b/modules/idm/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.picketlink</groupId>
 		<artifactId>picketlink-idm-parent</artifactId>
-		<version>2.6.1-SNAPSHOT</version>
+		<version>2.6.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/modules/idm/api/pom.xml
+++ b/modules/idm/api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.picketlink</groupId>
 		<artifactId>picketlink-idm-parent</artifactId>
-		<version>2.6.0-SNAPSHOT</version>
+		<version>2.6.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/modules/idm/complex-schema/pom.xml
+++ b/modules/idm/complex-schema/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-idm-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/idm/complex-schema/pom.xml
+++ b/modules/idm/complex-schema/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-idm-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/idm/drools/pom.xml
+++ b/modules/idm/drools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.picketlink</groupId>
 		<artifactId>picketlink-idm-parent</artifactId>
-		<version>2.6.1-SNAPSHOT</version>
+		<version>2.6.2-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/modules/idm/drools/pom.xml
+++ b/modules/idm/drools/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.picketlink</groupId>
 		<artifactId>picketlink-idm-parent</artifactId>
-		<version>2.6.0-SNAPSHOT</version>
+		<version>2.6.1-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/modules/idm/impl/pom.xml
+++ b/modules/idm/impl/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-idm-parent</artifactId>
-      <version>2.6.0-SNAPSHOT</version>
+      <version>2.6.1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/modules/idm/impl/pom.xml
+++ b/modules/idm/impl/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-idm-parent</artifactId>
-      <version>2.6.1-SNAPSHOT</version>
+      <version>2.6.2-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/modules/idm/pom.xml
+++ b/modules/idm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/idm/pom.xml
+++ b/modules/idm/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/idm/simple-schema/pom.xml
+++ b/modules/idm/simple-schema/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-idm-parent</artifactId>
-      <version>2.6.0-SNAPSHOT</version>
+      <version>2.6.1-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/modules/idm/simple-schema/pom.xml
+++ b/modules/idm/simple-schema/pom.xml
@@ -4,7 +4,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-idm-parent</artifactId>
-      <version>2.6.1-SNAPSHOT</version>
+      <version>2.6.2-SNAPSHOT</version>
       <relativePath>../pom.xml</relativePath>
    </parent>
 

--- a/modules/idm/tests/pom.xml
+++ b/modules/idm/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-idm-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/idm/tests/pom.xml
+++ b/modules/idm/tests/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-idm-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
 

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/json/pom.xml
+++ b/modules/json/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/oauth/pom.xml
+++ b/modules/oauth/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/oauth/pom.xml
+++ b/modules/oauth/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/rest/bin/pom.xml
+++ b/modules/rest/bin/pom.xml
@@ -16,7 +16,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-parent</artifactId>
-      <version>2.6.0-SNAPSHOT</version>
+      <version>2.6.1-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/modules/rest/bin/pom.xml
+++ b/modules/rest/bin/pom.xml
@@ -16,7 +16,7 @@
    <parent>
       <groupId>org.picketlink</groupId>
       <artifactId>picketlink-parent</artifactId>
-      <version>2.6.1-SNAPSHOT</version>
+      <version>2.6.2-SNAPSHOT</version>
       <relativePath>../../pom.xml</relativePath>
    </parent>
    <modelVersion>4.0.0</modelVersion>

--- a/modules/rest/pom.xml
+++ b/modules/rest/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/rest/pom.xml
+++ b/modules/rest/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/modules/social/pom.xml
+++ b/modules/social/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/modules/social/pom.xml
+++ b/modules/social/pom.xml
@@ -2,7 +2,7 @@
   <parent>
     <groupId>org.picketlink</groupId>
     <artifactId>picketlink-parent</artifactId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-parent</artifactId>
-  <version>2.6.1-SNAPSHOT</version>
+  <version>2.6.2-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PicketLink Parent</name>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>org.picketlink</groupId>
   <artifactId>picketlink-parent</artifactId>
-  <version>2.6.0-SNAPSHOT</version>
+  <version>2.6.1-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <name>PicketLink Parent</name>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>picketlink-parent</artifactId>
     <groupId>org.picketlink</groupId>
-    <version>2.6.1-SNAPSHOT</version>
+    <version>2.6.2-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -3,7 +3,7 @@
   <parent>
     <artifactId>picketlink-parent</artifactId>
     <groupId>org.picketlink</groupId>
-    <version>2.6.0-SNAPSHOT</version>
+    <version>2.6.1-SNAPSHOT</version>
     <relativePath>../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Picketlink 2.6.1 has a bug  that can't pass attributes to SP when SP submits another authentication for SSO after a user has been authenticated on IDP. 

This class org.picketlink.identity.federation.web.handlers.saml2.SAML2AttributeHandler needs to be modified. Line 134 -- 139:
        Map<String, Object> attribs = (Map<String, Object>) session.getAttribute(GeneralConstants.ATTRIBUTES);
        if (attribs == null) {
            attribs = this.attribManager.getAttributes(userPrincipal, attributeKeys);
            request.addOption(GeneralConstants.ATTRIBUTES, attribs);
            session.setAttribute(GeneralConstants.ATTRIBUTES, attribs);
        }

Change to:
        Map<String, Object> attribs = (Map<String, Object>) session.getAttribute(GeneralConstants.ATTRIBUTES);
        if (attribs == null) {
            attribs = this.attribManager.getAttributes(userPrincipal, attributeKeys);
            session.setAttribute(GeneralConstants.ATTRIBUTES, attribs);
        }
        request.addOption(GeneralConstants.ATTRIBUTES, attribs);
