### PR TITLE
PLANNER-579 Reduce WARN messages during startup

### DIFF
--- a/modules/base/impl/src/main/java/org/picketlink/extension/PicketLinkExtension.java
+++ b/modules/base/impl/src/main/java/org/picketlink/extension/PicketLinkExtension.java
@@ -63,11 +63,11 @@ public class PicketLinkExtension implements Extension {
      * @param pat
      * @param <T>
      */
-    <T> void vetoIdentityImplementations(@Observes ProcessAnnotatedType<T> pat) {
+    <T extends Identity> void vetoIdentityImplementations(@Observes ProcessAnnotatedType<T> pat) {
         final AnnotatedType<T> annotatedType = pat.getAnnotatedType();
         Class<T> javaClass = annotatedType.getJavaClass();
 
-        if (!Identity.class.equals(javaClass) && Identity.class.isAssignableFrom(javaClass)) {
+        if (!Identity.class.equals(javaClass)) {
             pat.veto();
         }
     }


### PR DESCRIPTION
Fixes warnings when starting OptaPlanner WB (https://github.com/droolsjbpm/optaplanner-wb/) in GWT Super Dev Mode

WARN  [org.jboss.weld.Event] WELD-000411: Observer method [BackedAnnotatedMethod] org.picketlink.extension.PicketLinkExtension.vetoIdentityImplementations(@Observes ProcessAnnotatedType<Object>) receives events for all annotated types. Consider restricting events using @WithAnnotations or a generic type with bounds.
